### PR TITLE
Use serviceAccountTemplate from values

### DIFF
--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -80,7 +80,10 @@ spec:
     {{ end }}
 
   # -- Configure the generation of the service account
-  serviceAccountTemplate: {}
+  {{- with .Values.cluster.serviceAccountTemplate }}
+  serviceAccountTemplate:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
   monitoring:
     enablePodMonitor: {{ and .Values.cluster.monitoring.enabled .Values.cluster.monitoring.podMonitor.enabled }}


### PR DESCRIPTION
`serviceAccountTemplate` was hardcoded as an empty object - this PR updates the cluster template to use the value specified in the chart values.
