### PR TITLE
Make pg_analytics optional

### DIFF
--- a/.github/workflows/tests-cluster-chainsaw.yaml
+++ b/.github/workflows/tests-cluster-chainsaw.yaml
@@ -12,7 +12,7 @@ jobs:
       tests: ${{ steps.listTests.outputs.tests }}
     steps:
       - name: Checkout
-        uses: actions/checkout@4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - id: listTests

--- a/charts/paradedb/templates/_bootstrap.tpl
+++ b/charts/paradedb/templates/_bootstrap.tpl
@@ -23,7 +23,6 @@ bootstrap:
     postInitApplicationSQL:
       {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") }}
       - CREATE EXTENSION IF NOT EXISTS pg_search;
-      - CREATE EXTENSION IF NOT EXISTS pg_analytics;
       - CREATE EXTENSION IF NOT EXISTS pg_ivm;
       - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS postgis;
@@ -42,7 +41,6 @@ bootstrap:
     postInitTemplateSQL:
       {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") }}
       - CREATE EXTENSION IF NOT EXISTS pg_search;
-      - CREATE EXTENSION IF NOT EXISTS pg_analytics;
       - CREATE EXTENSION IF NOT EXISTS pg_ivm;
       - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS postgis;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
We've seen small demand for pg_analytics. As such, we won't pre-install it in the database anymore. It'll still be possible to use it by running `CREATE EXTENSION pg_analytics;`.

## Why
^

## How
^

## Tests
^