### PR TITLE
feat: Added pgDumpExtraOptions and pgRestoreExtraOptions

### DIFF
--- a/charts/paradedb/templates/_bootstrap.tpl
+++ b/charts/paradedb/templates/_bootstrap.tpl
@@ -97,6 +97,14 @@ externalClusters:
         {{- . | toYaml | nindent 6 }}
       {{- end }}
       schemaOnly: {{ .Values.recovery.import.schemaOnly }}
+      {{ with .Values.recovery.import.pgDumpExtraOptions }}
+      pgDumpExtraOptions:
+        {{- . | toYaml | nindent 6 }}
+      {{- end }}
+      {{ with .Values.recovery.import.pgRestoreExtraOptions }}
+      pgRestoreExtraOptions:
+        {{- . | toYaml | nindent 6 }}
+      {{- end }}
 
 externalClusters:
   {{- include "cluster.externalSourceCluster" (list "importSource" .Values.recovery.import.source) | nindent 2 }}

--- a/charts/paradedb/test/postgresql-import/01-data_write.yaml
+++ b/charts/paradedb/test/postgresql-import/01-data_write.yaml
@@ -25,7 +25,9 @@ spec:
         command: ['sh', '-c']
         args:
          - |
+           set -e
            apk --no-cache add postgresql-client
            psql "$DB_URI" -c "CREATE DATABASE mygooddb;"
            psql "$DB_URI/mygooddb" -c "CREATE TABLE mygoodtable (id serial PRIMARY KEY);"
            psql "$DB_URI/mygooddb" -c "INSERT INTO mygoodtable VALUES (314159265);"
+           psql "$DB_URI/mygooddb" -c "CREATE TABLE mybadtable (id serial PRIMARY KEY);"

--- a/charts/paradedb/test/postgresql-import/02-import-cluster.yaml
+++ b/charts/paradedb/test/postgresql-import/02-import-cluster.yaml
@@ -5,6 +5,8 @@ recovery:
   import:
     type: "microservice"
     databases: [ "mygooddb" ]
+    pgDumpExtraOptions:
+      - --table=mygood*
     source:
       host: "source-paradedb-rw"
       username: "postgres"
@@ -20,7 +22,7 @@ recovery:
         key: tls.crt
 
 cluster:
-  instances: 2
+  instances: 1
   storage:
     size: 256Mi
   initdb:

--- a/charts/paradedb/test/postgresql-import/03-data_test.yaml
+++ b/charts/paradedb/test/postgresql-import/03-data_test.yaml
@@ -18,7 +18,12 @@ spec:
         command: ['sh', '-c']
         args:
          - |
+           set -e
            apk --no-cache add postgresql-client
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
            test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mygoodtable$$)' --csv -q 2>/dev/null)" = "t"
+           echo "mygoodtable exist"
+           test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mybadtable$$)' --csv -q 2>/dev/null)" = "f"
+           echo "mybadtable doesn't exist"
            test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM mygoodtable WHERE id = 314159265)' --csv -q 2>/dev/null)" = "t"
+           echo "mygoodtable contains the desired value"

--- a/charts/paradedb/test/postgresql-import/04-import-cluster-schema_only.yaml
+++ b/charts/paradedb/test/postgresql-import/04-import-cluster-schema_only.yaml
@@ -5,6 +5,8 @@ recovery:
   import:
     type: "microservice"
     databases: [ "mygooddb" ]
+    pgRestoreExtraOptions:
+      - --table=mygoodtable
     schemaOnly: true
     source:
       host: "source-paradedb-rw"
@@ -21,7 +23,7 @@ recovery:
         key: tls.crt
 
 cluster:
-  instances: 2
+  instances: 1
   storage:
     size: 256Mi
   initdb:

--- a/charts/paradedb/test/postgresql-import/05-data_test.yaml
+++ b/charts/paradedb/test/postgresql-import/05-data_test.yaml
@@ -18,7 +18,12 @@ spec:
         command: ['sh', '-c']
         args:
          - |
+           set -e
            apk --no-cache add postgresql-client
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
            test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mygoodtable$$)' --csv -q 2>/dev/null)" = "t"
-           test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM mygoodtable WHERE id = 314159265)' --csv -q 2>/dev/null)" = "f"
+           echo "mygoodtable exist"
+           test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mybadtable$$)' --csv -q 2>/dev/null)" = "f"
+           echo "mybadtable doesn't exist"
+           test "$(psql "${DB_URI}mygooddb" -t -c 'SELECT COUNT(*) FROM mygoodtable' --csv -q 2>/dev/null)" = "0"
+           echo "mygoodtable is empty"

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -140,6 +140,14 @@ recovery:
     postImportApplicationSQL: []
     # -- When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.
     schemaOnly: false
+    # -- List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your
+    # own risk, as the operator does not validate their content. Be aware that certain options may conflict with the
+    # operator's intended functionality or design.
+    pgDumpExtraOptions: []
+    # -- List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at
+    # your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the
+    # operator's intended functionality or design.
+    pgRestoreExtraOptions: []
     source:
       host: ""
       port: 5432


### PR DESCRIPTION
Adds `pgDumpExtraOptions` and `pgRestoreExtraOptions` as requested by @rebasedming.

P.S. Sorry it took so long. I just noticed an issue with the tests - the missing - `set -e` which made me re-evaluate the test results.