### PR TITLE
fix: Use encoded version of `hot_standby_feedback`

### DIFF
--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -88,7 +88,7 @@ spec:
     {{ end }}
     parameters:
       {{ if eq .Values.type "paradedb-enterprise" }}
-      hot_standby_feedback: on
+      hot_standby_feedback: "1"
       {{ end }}
       {{- with .Values.cluster.postgresql.parameters }}
       {{ toYaml . | nindent 6 }}

--- a/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster-assert.yaml
+++ b/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster-assert.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   postgresql:
     parameters:
-      hot_standby_feedback: "on"
-      cron.database_name: "postgres"
+      cron.database_name: postgres
+      hot_standby_feedback: "1"
 status:
   readyInstances: 2

--- a/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
+++ b/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
@@ -11,8 +11,8 @@ cluster:
     - name: paradedb-enterprise-registry-cred
   postgresql:
     parameters:
-      hot_standby_feedback: "on"
-      cron.database_name: "postgres"
+      cron.database_name: postgres
+      hot_standby_feedback: "1"
 
 backups:
   enabled: false


### PR DESCRIPTION
#106 failed due to encoding issues in the operator.