### PR TITLE
fix: If the managed extension is pg_search always use the same version as the docker image

### DIFF
--- a/charts/paradedb/templates/databases.yaml
+++ b/charts/paradedb/templates/databases.yaml
@@ -70,9 +70,10 @@ spec:
   {{- with .extensions }}
   extensions:
   {{- range . }}
+    {{- $extname := .name }}
     - name: {{ .name }}
       {{- with .version }}
-      version: {{ . }}
+      version: {{ eq $extname "pg_search" | ternary $.Values.version.paradedb . }}
       {{- end }}
       {{- with .schema }}
       schema: {{ . }}

--- a/charts/paradedb/templates/databases.yaml
+++ b/charts/paradedb/templates/databases.yaml
@@ -72,7 +72,7 @@ spec:
   {{- range . }}
     {{- $extname := .name }}
     - name: {{ .name }}
-      {{- with .version }}
+      {{- if or (not (empty .version)) (eq $extname "pg_search") }}
       version: {{ eq $extname "pg_search" | ternary $.Values.version.paradedb . }}
       {{- end }}
       {{- with .schema }}

--- a/charts/paradedb/test/database-management/02.1-extension-upgrade-init.yaml
+++ b/charts/paradedb/test/database-management/02.1-extension-upgrade-init.yaml
@@ -14,4 +14,3 @@ databases:
     extensions:
       - name: pg_search
         ensure: present
-        version: "0.15.20"

--- a/charts/paradedb/test/database-management/02.3-extension-upgrade-post.yaml
+++ b/charts/paradedb/test/database-management/02.3-extension-upgrade-post.yaml
@@ -14,4 +14,3 @@ databases:
     extensions:
       - name: pg_search
         ensure: present
-        version: "0.15.21"

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -534,7 +534,7 @@ databases: []
  #   encoding: UTF8                 # -- Maps to the ENCODING parameter.
  #   connectionLimit: -1            # -- Maps to the CONNECTION LIMIT parameter. -1 (the default) means no limit.
  #   tablespace: ""                 # -- Maps to the TABLESPACE parameter and ALTER DATABASE.
- #   databaseReclaimPolicy: retain  # -- One of: retaion / delete (retain by default).
+ #   databaseReclaimPolicy: retain  # -- One of: retain / delete (retain by default).
  #   schemas: []                    # -- List of schemas to be created in the database.
  #    # - name: myschema
  #    #   owner: paradedb           # -- Owner of the schema, defaults to the database owner.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
