### PR TITLE
feat: improved alerts so they include current disk space usage

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-low_disk_space-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-low_disk_space-critical.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance is running out of disk space!
   description: |-
-    ParadeDB CNPG Cluster "{{ .namespace }}/{{ .cluster }}" is running extremely low on disk space. Check attached PVCs!
+    ParadeDB CNPG Cluster "{{ .namespace }}/{{ .cluster }}" is running extremely low on disk space. Check attached PVCs! Current disk space usage is {{ .value }}% of the total capacity.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
 expr: |
   max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.9 OR
@@ -15,7 +15,7 @@ expr: |
       *
       on(namespace, persistentvolumeclaim) group_left(volume)
       kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
-  ) > 0.9
+  ) * 100 > 90
 for: 5m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-low_disk_space-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-low_disk_space-warning.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance is running out of disk space.
   description: |-
-    ParadeDB CNPG Cluster "{{ .namespace }}/{{ .cluster }}" is running low on disk space. Check attached PVCs.
+    ParadeDB CNPG Cluster "{{ .namespace }}/{{ .cluster }}" is running low on disk space. Check attached PVCs. Current disk space usage is {{ .value }}% of the total capacity.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
 expr: |
   max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.7 OR
@@ -15,7 +15,7 @@ expr: |
       *
       on(namespace, persistentvolumeclaim) group_left(volume)
       kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
-  ) > 0.7
+  ) * 100 > 70
 for: 5m
 labels:
   severity: warning


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds the current disk space usage to the `CNPGClusterLowDiskSpaceCritical` and `CNPGClusterLowDiskSpaceWarning` alerts so they are more descriptive.

## Why

This gives the user immediate information on the current disk usage so they can better understand the urgency of the alert.

## How

The  formula is adjusted so the output of the query is a human-readable percantage. Then the value of the expression is included in the alert description.

## Tests
