### PR TITLE
fix: resolve merge conflict markers in paradedb Chart.yaml

### DIFF
--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -22,10 +22,6 @@ description: Deploys and manages a ParadeDB CloudNativePG cluster and its associ
 kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/paradedb/paradedb/main/docs/logo/light.svg
 type: application
-<<<<<<< HEAD:charts/plugin-barman-cloud/Chart.yaml
-version: "0.6.0"
-appVersion: "v0.12.0"
-=======
 
 # The Chart version, set in the publish CI workflow from GitHub Actions Variables
 version: 0.0.0-generated-in-ci
@@ -34,7 +30,6 @@ version: 0.0.0-generated-in-ci
 # We default to v0.22.6 for testing and local development
 appVersion: 0.22.6
 
->>>>>>> 2e17b3d (ParadeDB Support (#1)):charts/paradedb/Chart.yaml
 sources:
   - https://github.com/paradedb/charts
 keywords:


### PR DESCRIPTION
## Summary
- Unresolved Git merge conflict markers were left in `charts/paradedb/Chart.yaml` (lines 25–37) from the initial ParadeDB support merge.
- This broke the `Publish ParadeDB Helm Charts to GitHub Pages` workflow with: `cannot load Chart.yaml: error converting YAML to JSON: yaml: line 26: could not find expected ':'`.
- Removed the conflict markers and the stray `plugin-barman-cloud` fields, keeping the ParadeDB chart's `version`/`appVersion` block.

Failing run: https://github.com/paradedb/charts/actions/runs/24410108611/job/71304202501

## Test plan
- [ ] `helm lint charts/paradedb`
- [ ] Publish workflow succeeds on merge to `dev`