### PR TITLE
chore: replace pg_cache_hit_ratio example with pg_database_size_bytes

### DIFF
--- a/charts/paradedb/examples/custom-queries.yaml
+++ b/charts/paradedb/examples/custom-queries.yaml
@@ -6,19 +6,18 @@ cluster:
   monitoring:
     enabled: true
     customQueries:
-      - name: "pg_cache_hit"
+      - name: "pg_database_size_bytes"
         query: |
           SELECT
             current_database() as datname,
-            sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio
-          FROM pg_statio_user_tables;
+            pg_database_size(current_database()) as size_bytes;
         metrics:
           - datname:
               usage: "LABEL"
               description: "Name of the database"
-          - ratio:
+          - size_bytes:
               usage: GAUGE
-              description: "Cache hit ratio"
+              description: "Size of the database in bytes"
 
 backups:
   enabled: false

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -113,16 +113,16 @@ metadata:
   name: monitoring-paradedb-monitoring-user-metrics
 data:
   custom-queries: |
-    pg_cache_hit_ratio:
-      query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+    pg_database_size_bytes:
+      query: "SELECT current_database() as datname, pg_database_size(current_database()) as size_bytes;"
       target_databases: ["*"]
       predicate_query: "SELECT 'paradedb';"
       metrics:
         - datname:
             description: Name of the database
             usage: LABEL
-        - ratio:
-            description: Cache hit ratio
+        - size_bytes:
+            description: Size of the database in bytes
             usage: GAUGE
 ---
 apiVersion: v1

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
@@ -23,17 +23,17 @@ cluster:
       pgStatStatements: true
       pgStatActivity: true
     customQueries:
-      - name: "pg_cache_hit_ratio"
-        query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+      - name: "pg_database_size_bytes"
+        query: "SELECT current_database() as datname, pg_database_size(current_database()) as size_bytes;"
         target_databases: ["*"]
         predicate_query: "SELECT '{{ .Values.type }}';"
         metrics:
           - datname:
               usage: "LABEL"
               description: "Name of the database"
-          - ratio:
+          - size_bytes:
               usage: GAUGE
-              description: "Cache hit ratio"
+              description: "Size of the database in bytes"
     podMonitor:
       labels:
         team-name: test-team

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -335,17 +335,17 @@ cluster:
     # -- Custom Prometheus metrics
     # Will be stored in the ConfigMap
     customQueries: []
-    #  - name: "pg_cache_hit_ratio"
-    #    query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+    #  - name: "pg_database_size_bytes"
+    #    query: "SELECT current_database() as datname, pg_database_size(current_database()) as size_bytes;"
     #    target_databases: ["*"]
     #    predicate_query: "SELECT '{{ .Values.version.postgresql }}';"
     #    metrics:
     #      - datname:
     #          usage: "LABEL"
     #          description: "Name of the database"
-    #      - ratio:
+    #      - size_bytes:
     #          usage: GAUGE
-    #          description: "Cache hit ratio"
+    #          description: "Size of the database in bytes"
     # -- The list of secrets containing the custom queries
     customQueriesSecret: []
     #  - name: custom-queries-secret


### PR DESCRIPTION
## Summary
- The `pg_cache_hit_ratio` query used as the documented `customQueries` example (heap_blks_hit / heap_blks_read over `pg_statio_user_tables`) is a misleading default: it covers only user-table heap blocks and ignores index/catalog cache behavior, which is usually what matters for cache-pressure analysis.
- Its only live consumer — MCC's `mcc-customer` Cache Hit Ratio panel — has been switched (paradedb/mcc#105) to derive cache hit ratio from the standard `cnpg_pg_stat_database_blks_hit` / `cnpg_pg_stat_database_blks_read` metrics that CNPG exports by default. The companion BYOC change (paradedb/terraform-paradedb-byoc#946) drops the corresponding live customQueries entry on the MCC monitoring DB.
- Replace the `pg_cache_hit_ratio` example everywhere it appears in this chart with a neutral `pg_database_size_bytes` query, so the `customQueries` mechanism is still demonstrated and tested without implying a recommended (and misleading) metric.

Files touched:
- `charts/paradedb/values.yaml` — commented example block
- `charts/paradedb/examples/custom-queries.yaml`
- `charts/paradedb/test/monitoring/01-monitoring_cluster.yaml` + `-assert.yaml`

## Test plan
- [x] `helm template` / chart test still passes with the swapped query.