### PR TITLE
feat(monitoring): add pg_stat_activity long-running query instrumentation

### DIFF
--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -133,7 +133,7 @@ spec:
 
   monitoring:
     disableDefaultQueries: {{ .Values.cluster.monitoring.disableDefaultQueries }}
-    {{- if or .Values.cluster.monitoring.instrumentation.paradedbIndex .Values.cluster.monitoring.instrumentation.logicalReplication .Values.cluster.monitoring.instrumentation.pgStatStatements (not (empty .Values.cluster.monitoring.customQueries)) }}
+    {{- if or .Values.cluster.monitoring.instrumentation.paradedbIndex .Values.cluster.monitoring.instrumentation.logicalReplication .Values.cluster.monitoring.instrumentation.pgStatStatements .Values.cluster.monitoring.instrumentation.pgStatActivity (not (empty .Values.cluster.monitoring.customQueries)) }}
     customQueriesConfigMap:
     {{- if .Values.cluster.monitoring.instrumentation.paradedbIndex }}
       - name: {{ include "cluster.fullname" . }}-monitoring-paradedb-index
@@ -145,6 +145,10 @@ spec:
     {{- end }}
     {{- if .Values.cluster.monitoring.instrumentation.pgStatStatements }}
       - name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-statements
+        key: custom-queries
+    {{- end }}
+    {{- if .Values.cluster.monitoring.instrumentation.pgStatActivity }}
+      - name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-activity
         key: custom-queries
     {{- end }}
     {{- if not (empty .Values.cluster.monitoring.customQueries) }}

--- a/charts/paradedb/templates/monitoring-pg-stat-activity.yaml
+++ b/charts/paradedb/templates/monitoring-pg-stat-activity.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.cluster.monitoring.instrumentation.pgStatActivity }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-activity
+  namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/reload: ""
+    {{- include "cluster.labels" . | nindent 4 }}
+data:
+  custom-queries: |
+    pg_stat_activity_long:
+      query: |
+        WITH databases AS (SELECT current_database() AS datname),
+             long_running_stats AS (SELECT datname
+                                       , COUNT(datname) AS count
+                                       , EXTRACT(epoch FROM COALESCE(AVG(now() - query_start), interval '0 seconds')) AS avg_duration
+                                       , EXTRACT(epoch FROM COALESCE(MAX(now() - query_start), interval '0 seconds')) AS max_duration
+                                  FROM pg_stat_activity
+                                  WHERE (now() - query_start) >= interval '30 seconds' AND state = 'active'
+                                  GROUP BY datname)
+        SELECT databases.datname
+             , COALESCE(avg_duration, 0) AS running_avg_duration
+             , COALESCE(max_duration, 0) AS running_max_duration
+             , COALESCE(count, 0) AS running_count
+        FROM databases
+        LEFT JOIN long_running_stats ON databases.datname = long_running_stats.datname;
+      target_databases: ["*"]
+      metrics:
+        - datname:
+            description: Name of the database
+            usage: LABEL
+        - running_avg_duration:
+            description: Average duration of queries running for longer than 30s
+            usage: GAUGE
+        - running_max_duration:
+            description: Maximum duration of queries running for longer than 30s
+            usage: GAUGE
+        - running_count:
+            description: Number of currently running queries for longer than 30s
+            usage: GAUGE
+    pg_stat_activity_long_running:
+      query: |
+        WITH buckets (bucket) AS (
+            VALUES
+                ('[0, 5]'::numrange),
+                ('[0, 60]'::numrange),
+                ('[0, 600]'::numrange),
+                ('[0, 3600]'::numrange),
+                ('[0, 7200]'::numrange),
+                ('[0, 10800]'::numrange),
+                ('[0, 86400]'::numrange),
+                ('[0, 172800]'::numrange),
+                ('[0, infinity]'::numrange)
+        ),
+        databases AS (SELECT current_database() AS datname),
+        db_buckets AS (
+            SELECT d.datname, b.bucket
+            FROM databases d CROSS JOIN buckets b
+        ),
+        bucketed_counts AS (
+            SELECT
+                db_buckets.datname,
+                upper(db_buckets.bucket) AS le,
+                COUNT(a.*) AS bucket_count
+            FROM db_buckets
+            LEFT JOIN pg_stat_activity a
+                ON a.datname = db_buckets.datname
+               AND a.state = 'active'
+               AND EXTRACT(epoch FROM now() - a.query_start) <@ db_buckets.bucket
+            GROUP BY db_buckets.datname, db_buckets.bucket
+        ),
+        totals AS (
+            SELECT
+                datname,
+                COUNT(*) AS total_count,
+                SUM(EXTRACT(epoch FROM now() - query_start)) AS total_duration
+            FROM pg_stat_activity
+            WHERE state = 'active' AND datname IS NOT NULL
+            GROUP BY datname
+        )
+        SELECT bc.datname
+            , ARRAY_AGG(le ORDER BY le) AS queries
+            , ARRAY_AGG(bucket_count ORDER BY le) AS queries_bucket
+            , COALESCE(t.total_count, 0) AS queries_count
+            , COALESCE(t.total_duration, 0) AS queries_sum
+        FROM bucketed_counts bc
+        LEFT JOIN totals t ON bc.datname = t.datname
+        GROUP BY bc.datname, t.total_count, t.total_duration
+        ORDER BY bc.datname;
+      target_databases: ["*"]
+      metrics:
+        - datname:
+            description: Name of the database
+            usage: LABEL
+        - queries:
+            description: Long running queries distribution
+            usage: HISTOGRAM
+{{- end }}

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -20,6 +20,8 @@ spec:
           key: custom-queries
         - name: monitoring-paradedb-monitoring-pg-stat-statements
           key: custom-queries
+        - name: monitoring-paradedb-monitoring-pg-stat-activity
+          key: custom-queries
         - name: monitoring-paradedb-monitoring-user-metrics
           key: custom-queries
       enablePodMonitor: false
@@ -137,6 +139,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: monitoring-paradedb-monitoring-pg-stat-statements
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-paradedb-monitoring-pg-stat-activity
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
@@ -21,6 +21,7 @@ cluster:
       paradedbIndex: true
       logicalReplication: true
       pgStatStatements: true
+      pgStatActivity: true
     customQueries:
       - name: "pg_cache_hit_ratio"
         query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -88,3 +88,12 @@ spec:
             curl $POD_URL | grep paradedb_index_layer_segments_count
             echo "paradedb_index_layer_segments_sum"
             curl $POD_URL | grep paradedb_index_layer_segments_sum
+
+            echo "pg_stat_activity_long_running_avg_duration"
+            curl $POD_URL | grep pg_stat_activity_long_running_avg_duration
+            echo "pg_stat_activity_long_running_max_duration"
+            curl $POD_URL | grep pg_stat_activity_long_running_max_duration
+            echo "pg_stat_activity_long_running_count"
+            curl $POD_URL | grep pg_stat_activity_long_running_count
+            echo "pg_stat_activity_long_running_queries_bucket"
+            curl $POD_URL | grep pg_stat_activity_long_running_queries_bucket

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -309,6 +309,8 @@ cluster:
       logicalReplication: true
       # -- Enable pg_stat_statements metrics
       pgStatStatements: true
+      # -- Enable pg_stat_activity long-running query metrics
+      pgStatActivity: true
     podMonitor:
       # -- Whether to enable the PodMonitor
       enabled: true


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds a new chart-managed monitoring instrumentation toggle, `cluster.monitoring.instrumentation.pgStatActivity` (default `true`), that ships the `pg_stat_activity_long` and `pg_stat_activity_long_running` custom queries via a ConfigMap.

This restores the following metrics, which the bundled `paradedb-dashboard.json` already references:

- `cnpg_pg_stat_activity_long_running_avg_duration`
- `cnpg_pg_stat_activity_long_running_max_duration`
- `cnpg_pg_stat_activity_long_running_count`
- `cnpg_pg_stat_activity_long_running_queries_bucket`

## Why

The custom queries that produce these metrics used to live in `terraform-paradedb-byoc` (`infrastructure/shared/paradedb/monitoring_config.tf`). PR paradedb/terraform-paradedb-byoc#715 ("logical replication and paradedb index instrumentation managed by the chart") moved monitoring instrumentation into this chart and emptied `customQueries` to `[]`. The `pg_stat_activity_long*` queries were never ported across, so the "PG Stat Activity Statistics" panels in the dashboard show "No data" on every cluster on the new chart.

## How

- New template `charts/paradedb/templates/monitoring-pg-stat-activity.yaml` containing the two queries (lifted verbatim from the original `monitoring_config.tf`).
- New value `cluster.monitoring.instrumentation.pgStatActivity: true` in `values.yaml`.
- `templates/cluster.yaml` wires the new ConfigMap into `monitoring.customQueriesConfigMap` when the toggle is on.

## Tests

- `helm lint charts/paradedb` passes.
- `helm template ... --show-only templates/monitoring-pg-stat-activity.yaml` renders the expected ConfigMap; with the toggle off the template renders empty.
- `helm template ... --show-only templates/cluster.yaml` includes `monitoring-pg-stat-activity` under `customQueriesConfigMap`.
- Updated chainsaw fixtures: `01-monitoring_cluster.yaml` enables the new toggle, `01-monitoring_cluster-assert.yaml` asserts the new ConfigMap and its presence in the cluster spec, `03-metrics-test.yaml` greps the four new metrics from `/metrics`.