### PR TITLE
fix(test): remove race condition in console-statefulset chainsaw test

### DIFF
--- a/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
+++ b/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
@@ -25,14 +25,18 @@ spec:
             file: ./01-console_test_cluster-assert.yaml
         - script:
             content: |
-              kubectl --namespace $NAMESPACE wait --for=condition=ready clusters.postgresql.cnpg.io/console-test-paradedb --timeout=60s
-              kubectl --namespace $NAMESPACE wait --for=condition=ready pod/console-test-paradedb-console-0 --timeout=60s
-              kubectl --namespace $NAMESPACE exec pod/console-test-paradedb-console-0 -- bash -c 'while true; do command -v psql && break || sleep 2; done'
-              echo 'nohup psql $DB_SUPERUSER_URI -c "SELECT PG_SLEEP(120);" 2>&1 > command.log &' | kubectl --namespace $NAMESPACE exec --stdin pod/console-test-paradedb-console-0 -- bash &
-              sleep 60
-              PSQL_RUNNING=$(kubectl --namespace $NAMESPACE exec statefulsets/console-test-paradedb-console -- bash -c 'ps -ef | grep psql | wc -l')
+              kubectl --namespace $NAMESPACE wait --for=condition=ready clusters.postgresql.cnpg.io/console-test-paradedb --timeout=120s
+              kubectl --namespace $NAMESPACE wait --for=condition=ready pod/console-test-paradedb-console-0 --timeout=120s
+              kubectl --namespace $NAMESPACE exec pod/console-test-paradedb-console-0 -- bash -c 'until command -v psql >/dev/null; do sleep 2; done'
+              kubectl --namespace $NAMESPACE exec pod/console-test-paradedb-console-0 -- bash -c 'until psql "$DB_SUPERUSER_URI" -c "SELECT 1" >/dev/null 2>&1; do sleep 2; done'
+              kubectl --namespace $NAMESPACE exec pod/console-test-paradedb-console-0 -- bash -c 'nohup psql "$DB_SUPERUSER_URI" -c "SELECT PG_SLEEP(120);" >/tmp/command.log 2>&1 & disown'
+              for _ in $(seq 1 30); do
+                PSQL_RUNNING=$(kubectl --namespace $NAMESPACE exec statefulsets/console-test-paradedb-console -- pgrep -fc 'psql.*PG_SLEEP' 2>/dev/null || echo 0)
+                [ "$PSQL_RUNNING" -ge 1 ] && break
+                sleep 2
+              done
               echo "PSQL_RUNNING: $PSQL_RUNNING"
-              [ $PSQL_RUNNING -gt 3 ] || exit 1
+              [ "$PSQL_RUNNING" -ge 1 ] || exit 1
     - name: Cleanup
       try:
         - script:

--- a/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
+++ b/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
@@ -8,7 +8,7 @@ spec:
   timeouts:
     apply: 1s
     assert: 10s
-    cleanup: 3m
+    cleanup: 5m
     exec: 5m
   steps:
     - name: Install a cluster with a console enabled
@@ -42,4 +42,5 @@ spec:
       try:
         - script:
             content: |
-              helm uninstall --namespace $NAMESPACE console-test
+              kubectl --namespace $NAMESPACE delete cluster console-test-paradedb --ignore-not-found --wait=true --timeout=3m
+              helm uninstall --namespace $NAMESPACE --wait --timeout 3m console-test

--- a/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
+++ b/charts/paradedb/test/console-statefulset/chainsaw-test.yaml
@@ -8,7 +8,7 @@ spec:
   timeouts:
     apply: 1s
     assert: 10s
-    cleanup: 1m
+    cleanup: 3m
     exec: 5m
   steps:
     - name: Install a cluster with a console enabled
@@ -37,6 +37,7 @@ spec:
               done
               echo "PSQL_RUNNING: $PSQL_RUNNING"
               [ "$PSQL_RUNNING" -ge 1 ] || exit 1
+              kubectl --namespace $NAMESPACE exec statefulsets/console-test-paradedb-console -- pkill -f 'psql.*PG_SLEEP' || true
     - name: Cleanup
       try:
         - script:


### PR DESCRIPTION
## Summary
- The launching `kubectl exec --stdin ... bash &` was backgrounded locally, so the outer `sleep 60` could start before the inner shell launched psql.
- `ps -ef | grep psql | wc -l > 3` matched incidental shell internals (the surrounding `bash -c '... psql ...'` and the `grep psql` itself) rather than the actual long-running psql, making the threshold flaky.
- The pod being `Ready` did not mean Postgres was accepting connections; psql could connect-and-exit before the assertion ran.

## How
- Single synchronous `kubectl exec ... bash -c 'nohup ... & disown'` to launch the long query, replacing the fire-and-forget `&` on the local kubectl client.
- Poll `until psql ... SELECT 1` so we wait for Postgres to actually accept connections, not just for the pod to be `Ready`.
- Replace the `grep | wc -l > 3` check with `pgrep -fc 'psql.*PG_SLEEP' >= 1` inside a 60s polling loop instead of one fixed `sleep 60`.
- Cluster/pod readiness timeouts bumped from 60s to 120s; log redirected to `/tmp/command.log` so it does not depend on pod cwd.

## Test plan
- [ ] `chainsaw test charts/paradedb/test/console-statefulset` passes locally / in CI
- [ ] Re-run a few times to confirm the flakiness is gone