### PR TITLE
fix(monitoring): name cluster PodMonitor after the cluster

### DIFF
--- a/charts/paradedb/templates/podmonitor-cluster.yaml
+++ b/charts/paradedb/templates/podmonitor-cluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "cluster.fullname" . }}-cluster-podmonitor
+  name: {{ include "cluster.fullname" . }}
   namespace: {{ include "cluster.namespace" . }}
   labels:
     cnpg.io/cluster: {{ include "cluster.fullname" . }}


### PR DESCRIPTION
## Summary
- Drop the `-cluster-podmonitor` suffix from the chart-managed PodMonitor so the resulting Prometheus `job` label is `<namespace>/<cluster>` — matching what the CNPG operator produced when `Cluster.spec.monitoring.enablePodMonitor: true` was set in chart versions <= 0.13.12.
- Dashboards and alert rules that filter by `job="<namespace>/<cluster>"` (the standard convention) silently stopped matching after the chart took over PodMonitor ownership in 0.13.13, even though the scrape itself continued working under the new `<ns>/<cluster>-cluster-podmonitor` job label.
- Discovered while upgrading a customer cluster from 0.11.10 to 0.14.0: ParadeDB Index panels (Segment count / Relation size / Layer Segments) went blank because the dashboards filter by `job="$cnpgNamespace/$cnpgCluster"`, while replication-lag panels showed duplicated tiles per pod (because they don't filter by `job` and both the operator-orphaned and chart-managed scrape paths were active simultaneously).

## Test plan
- [x] `helm template` with `cluster.monitoring.enabled=true` and confirm the PodMonitor `metadata.name` equals the cluster fullname (e.g. `paradedb`) instead of `paradedb-cluster-podmonitor`.
- [x] Existing chainsaw monitoring tests continue to pass (the assertion file matches PodMonitors by labels, not name).
- [x] On a freshly-installed cluster, confirm scraped series carry `job="<ns>/<cluster>"` end-to-end.
- [x] On an in-place upgrade from 0.11.x: the operator-managed PodMonitor named `<cluster>` is removed by CNPG when `enablePodMonitor` becomes false. Operators must manually clean up any orphaned VMPodScrape with the same name left by the victoria-metrics operator's PodMonitor→VMPodScrape converter (`kubectl -n <ns> delete vmpodscrape <cluster>`); a follow-up PR can add a Helm hook for this.