### PR TITLE
fix(monitoring): exclude walsenders from long-running query metrics

### DIFF
--- a/charts/paradedb/templates/monitoring-pg-stat-activity.yaml
+++ b/charts/paradedb/templates/monitoring-pg-stat-activity.yaml
@@ -17,7 +17,9 @@ data:
                                        , EXTRACT(epoch FROM COALESCE(AVG(now() - query_start), interval '0 seconds')) AS avg_duration
                                        , EXTRACT(epoch FROM COALESCE(MAX(now() - query_start), interval '0 seconds')) AS max_duration
                                   FROM pg_stat_activity
-                                  WHERE (now() - query_start) >= interval '30 seconds' AND state = 'active'
+                                  WHERE (now() - query_start) >= interval '30 seconds'
+                                    AND state = 'active'
+                                    AND backend_type = 'client backend'
                                   GROUP BY datname)
         SELECT databases.datname
              , COALESCE(avg_duration, 0) AS running_avg_duration
@@ -67,6 +69,7 @@ data:
             LEFT JOIN pg_stat_activity a
                 ON a.datname = db_buckets.datname
                AND a.state = 'active'
+               AND a.backend_type = 'client backend'
                AND EXTRACT(epoch FROM now() - a.query_start) <@ db_buckets.bucket
             GROUP BY db_buckets.datname, db_buckets.bucket
         ),
@@ -76,7 +79,9 @@ data:
                 COUNT(*) AS total_count,
                 SUM(EXTRACT(epoch FROM now() - query_start)) AS total_duration
             FROM pg_stat_activity
-            WHERE state = 'active' AND datname IS NOT NULL
+            WHERE state = 'active'
+              AND datname IS NOT NULL
+              AND backend_type = 'client backend'
             GROUP BY datname
         )
         SELECT bc.datname


### PR DESCRIPTION
## Summary
- The `pg_stat_activity_long` and `pg_stat_activity_long_running` custom queries shipped by the chart filter `pg_stat_activity` on `state = 'active'`, which incorrectly counts walsender backends as long-running user queries. Walsenders (physical replication standbys and logical replication slots like Debezium / Decoderbufs subscribers) sit permanently in `state = 'active'` while waiting on WAL, so any cluster with a streaming replica or a CDC subscriber permanently reports phantom long-running queries.
- Restrict both queries to `backend_type = 'client backend'` so only real user-initiated queries contribute to the metrics. This fixes false-positive 2h+ "long-running query" entries observed on a customer with a logical replication subscriber.

## Test plan
- [x] On a cluster with at least one standby and an active logical replication subscriber, confirm `pg_stat_activity_long_running_count` is 0 (and the histogram empty) when no user query has been running for >30s.
- [x] Run a deliberate `SELECT pg_sleep(60)` from psql and verify it shows up in the metric.
- [x] Existing chainsaw monitoring tests continue to pass.