### PR TITLE
fix: align minio backup/restore test with upstream

### DIFF
--- a/charts/paradedb/test/paradedb-import/chainsaw-test.yaml
+++ b/charts/paradedb/test/paradedb-import/chainsaw-test.yaml
@@ -1,6 +1,7 @@
 ##
-# This is a test that provisions a regular (non CNPG) PostgreSQL cluster and attempts to perform a
-# pg_basebackup recovery into a ParadeDB cluster.
+# This is a test that provisions a source PostgreSQL cluster and imports its databases into a ParadeDB
+# cluster using CNPG's `import` bootstrap (pg_dump/pg_restore), covering both the full and schema-only
+# import variants.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:

--- a/charts/paradedb/test/paradedb-minio-backup-restore/04-data_write.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/04-data_write.yaml
@@ -45,10 +45,6 @@ spec:
         command: ['sh', '-c']
         args:
          - |
-           apk --no-cache add postgresql-client kubectl coreutils
+           apk --no-cache add postgresql-client
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
            psql "$DB_URI" -c "CREATE TABLE mygoodtable (id serial PRIMARY KEY);"
-           sleep 5
-           DATE_NO_BAD_TABLE=$(date --rfc-3339=ns)
-           kubectl create configmap date-no-bad-table --from-literal=date="$DATE_NO_BAD_TABLE"
-           sleep 5

--- a/charts/paradedb/test/paradedb-minio-backup-restore/06-post_backup_data_write.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/06-post_backup_data_write.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: configmap-creator-sa
       restartPolicy: OnFailure
       containers:
       - name: data-write
@@ -22,6 +23,9 @@ spec:
         command: ['sh', '-c']
         args:
          - |
-           apk --no-cache add postgresql-client
+           apk --no-cache add postgresql-client kubectl coreutils
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
+           DATE_NO_BAD_TABLE=$(date --rfc-3339=ns)
+           kubectl create configmap date-no-bad-table --from-literal=date="$DATE_NO_BAD_TABLE"
+           sleep 5
            psql "$DB_URI" -c "CREATE TABLE mybadtable (id serial PRIMARY KEY);"

--- a/charts/paradedb/test/paradedb-minio-backup-restore/09-recovery_backup_cluster-assert.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/09-recovery_backup_cluster-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: recovery-backup-paradedb
+status:
+  readyInstances: 2

--- a/charts/paradedb/test/paradedb-minio-backup-restore/09-recovery_backup_cluster.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/09-recovery_backup_cluster.yaml
@@ -1,0 +1,51 @@
+##
+# Recovery from a CNPG Backup object (no PITR target): the cluster is
+# bootstrapped from the `post-init-backup` Backup and replays all archived
+# WAL, so it comes up with the latest data.
+type: paradedb
+mode: recovery
+cluster:
+  instances: 2
+  storage:
+    size: 256Mi
+
+recovery:
+  method: backup
+  backupName: "post-init-backup"
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/paradedb/v1"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"
+
+backups:
+  enabled: true
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/paradedb/v2"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"

--- a/charts/paradedb/test/paradedb-minio-backup-restore/10-data_test-assert.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/10-data_test-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-backup
+status:
+  succeeded: 1

--- a/charts/paradedb/test/paradedb-minio-backup-restore/10-data_test.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/10-data_test.yaml
@@ -1,0 +1,25 @@
+##
+# Verify the backup-recovery cluster restored the pre-backup data.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-backup
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: data-test
+        env:
+          - name: DB_URI
+            valueFrom:
+              secretKeyRef:
+                name: recovery-backup-paradedb-superuser
+                key: uri
+        image: alpine:3.19
+        command: ['sh', '-c']
+        args:
+         - |
+           apk --no-cache add postgresql-client
+           DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
+           test "$(psql $DB_URI -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mygoodtable$$)' --csv -q 2>/dev/null)" = "t"

--- a/charts/paradedb/test/paradedb-minio-backup-restore/11-recovery_object_store_cluster-assert.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/11-recovery_object_store_cluster-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: recovery-object-store-paradedb
+status:
+  readyInstances: 2

--- a/charts/paradedb/test/paradedb-minio-backup-restore/11-recovery_object_store_cluster.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/11-recovery_object_store_cluster.yaml
@@ -1,0 +1,52 @@
+##
+# Recovery directly from the barman object store (no CNPG Backup object): the
+# cluster bootstraps from the source cluster's archive under serverName
+# `paradedb` and replays all archived WAL.
+type: paradedb
+mode: recovery
+cluster:
+  instances: 2
+  storage:
+    size: 256Mi
+
+recovery:
+  method: object_store
+  # serverName of the source cluster, i.e. its name in the object store.
+  clusterName: "paradedb"
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/paradedb/v1"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"
+
+backups:
+  enabled: true
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/paradedb/v2"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"

--- a/charts/paradedb/test/paradedb-minio-backup-restore/12-data_test-assert.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/12-data_test-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-object-store
+status:
+  succeeded: 1

--- a/charts/paradedb/test/paradedb-minio-backup-restore/12-data_test.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/12-data_test.yaml
@@ -1,0 +1,25 @@
+##
+# Verify the object-store-recovery cluster restored the pre-backup data.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-object-store
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: data-test
+        env:
+          - name: DB_URI
+            valueFrom:
+              secretKeyRef:
+                name: recovery-object-store-paradedb-superuser
+                key: uri
+        image: alpine:3.19
+        command: ['sh', '-c']
+        args:
+         - |
+           apk --no-cache add postgresql-client
+           DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
+           test "$(psql $DB_URI -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mygoodtable$$)' --csv -q 2>/dev/null)" = "t"

--- a/charts/paradedb/test/paradedb-minio-backup-restore/chainsaw-test.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/chainsaw-test.yaml
@@ -161,8 +161,72 @@ spec:
             name: data-test-backup-pitr
         - podLogs:
             selector: batch.kubernetes.io/job-name=data-test-backup-pitr
+    - name: Create a recovery cluster from a backup
+      try:
+        - script:
+            content: |
+              helm upgrade \
+                --install \
+                --namespace $NAMESPACE \
+                --values ./09-recovery_backup_cluster.yaml \
+                --wait \
+                recovery-backup ../../
+        - assert:
+            file: ./09-recovery_backup_cluster-assert.yaml
+      catch:
+        - describe:
+            apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+        - podLogs:
+            selector: cnpg.io/cluster=recovery-backup-paradedb
+    - name: Verify the data on the backup recovery cluster exists
+      try:
+        - apply:
+            file: 10-data_test.yaml
+        - assert:
+            file: 10-data_test-assert.yaml
+      catch:
+        - describe:
+            apiVersion: batch/v1
+            kind: Job
+            name: data-test-backup
+        - podLogs:
+            selector: batch.kubernetes.io/job-name=data-test-backup
+    - name: Create a recovery cluster from the object store
+      try:
+        - script:
+            content: |
+              helm upgrade \
+                --install \
+                --namespace $NAMESPACE \
+                --values ./11-recovery_object_store_cluster.yaml \
+                --wait \
+                recovery-object-store ../../
+        - assert:
+            file: ./11-recovery_object_store_cluster-assert.yaml
+      catch:
+        - describe:
+            apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+        - podLogs:
+            selector: cnpg.io/cluster=recovery-object-store-paradedb
+    - name: Verify the data on the object store recovery cluster exists
+      try:
+        - apply:
+            file: 12-data_test.yaml
+        - assert:
+            file: 12-data_test-assert.yaml
+      catch:
+        - describe:
+            apiVersion: batch/v1
+            kind: Job
+            name: data-test-object-store
+        - podLogs:
+            selector: batch.kubernetes.io/job-name=data-test-object-store
     - name: Cleanup
       try:
         - script:
             content: |
               helm uninstall --namespace $NAMESPACE paradedb
+              helm uninstall --namespace $NAMESPACE recovery-backup
+              helm uninstall --namespace $NAMESPACE recovery-object-store

--- a/charts/paradedb/test/paradedb-pg_basebackup/chainsaw-test.yaml
+++ b/charts/paradedb/test/paradedb-pg_basebackup/chainsaw-test.yaml
@@ -3,7 +3,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: postgresql-pg-basebackup
+  name: paradedb-pg-basebackup
 spec:
   timeouts:
     apply: 1s


### PR DESCRIPTION
Fixes the `paradedb-minio-backup-restore` suite (and two stray test files) to match upstream `cloudnative-pg/charts`. Broken out of #199, which is stacked on top of this branch (it carries only the 0.24.0 version bump).

## Commits

1. **`fix: move PITR target after backup completion`** (@jamesblackwood-sewell, author preserved) — the PITR recovery-target timestamp was captured in `04-data_write.yaml` *before* the backup, making it an invalid recovery target (earlier than the base backup's consistent recovery point). Moved into `06-post_backup_data_write.yaml`, after the backup and before `mybadtable`, matching upstream.

2. **`test: add backup and object-store recovery scenarios`** — the suite only exercised PITR recovery; upstream also covers plain **backup recovery** and **object-store recovery** as separate clusters. Added both:
   - `09`/`10` — recovery from a CNPG Backup object (cluster `recovery-backup-paradedb`)
   - `11`/`12` — recovery directly from the barman object store (cluster `recovery-object-store-paradedb`, `serverName: paradedb`)

   Each data-test asserts the pre-backup data was restored, mirroring upstream's data tests. Both clusters render-verified with `helm template`.

3. **`test: fix stale chainsaw test name and inaccurate comment`** — `paradedb-pg_basebackup` test name was still `postgresql-pg-basebackup`; `paradedb-import` header comment described a pg_basebackup recovery when it is a CNPG `import` test.

## Step layout (minio-backup-restore)

```
07/08  recovery from backup + PITR target   (existing, target fixed)
09/10  recovery from a CNPG Backup object    (added)
11/12  recovery from the object store        (added)
```

## Validation

Verified via `helm template` (correct `bootstrap.recovery` + `externalClusters`) and YAML lint. The chainsaw e2e runs in CI.