### PR TITLE
fix(ci): use client-id for GitHub App token in publish workflow

### DIFF
--- a/.github/workflows/paradedb-publish-chart.yml
+++ b/.github/workflows/paradedb-publish-chart.yml
@@ -87,7 +87,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Run chart-releaser


### PR DESCRIPTION
## What
`actions/create-github-app-token@v3` deprecated the `app-id` input, and the `PARADEDB_GITHUB_APP_ID` org variable was deleted (it now resolves empty). Swap to the `client-id` input pointing at the existing `PARADEDB_GITHUB_APP_CLIENT_ID` org variable.

```diff
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
```

## Why
Fixes the "Generate GitHub App Token" step failure in the ParadeDB Publish Chart workflow:
> The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.

Ref: failed run https://github.com/paradedb/charts/actions/runs/27789761403

## Note
The publish workflow only triggers on push to `main` (and `workflow_dispatch`), so it does not run on this PR — it'll take effect once merged and the workflow next runs on `main`.