### PR TITLE
chore: CI smoke test on dev (post upstream-main rebase)

### DIFF
--- a/.ci-smoke-test
+++ b/.ci-smoke-test
@@ -1,0 +1,1 @@
+CI smoke test for upstream-main rebase + pg_stat_statements rework. Safe to delete.


### PR DESCRIPTION
Dummy PR to run the chainsaw suite + codespell against the rebased `dev` (now on upstream-main `f06b7fd`), validating the pg_stat_statements rework (gated, default true) in the bootstrap/monitoring templates.

Single throwaway file — **do not merge**; close once CI is green.