### PR TITLE
feat(paradedb): default-deny NetworkPolicies for multi-tenant isolation

### DIFF
--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -184,10 +184,6 @@ Additionally, we recommend enabling the `kube-state-metrics` CRD monitoring and 
 There are several configuration examples in the [examples](examples) directory. Refer to them for a basic setup and
 refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentation/current/) for more advanced configurations.
 
-## Requirements
-
-Kubernetes: `>=1.29.0-0`
-
 ## Values
 
 | Key | Type | Default | Description |
@@ -243,7 +239,7 @@ Kubernetes: `>=1.29.0-0`
 | cluster.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
 | cluster.imagePullSecrets | list | `[]` | The list of pull secrets to be used to pull the images. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference |
 | cluster.initdb | object | `{"database":"paradedb"}` | BootstrapInitDB is the configuration of the bootstrap process when initdb is used. See: https://cloudnative-pg.io/documentation/current/bootstrap/ See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb |
-| cluster.instances | int | `3` | Number of instances |
+| cluster.instances | int | `1` | Number of instances |
 | cluster.logLevel | string | `"info"` | The instances' log level, one of the following values: error, warning, info (default), debug, trace |
 | cluster.monitoring.customQueries | list | `[]` | Custom Prometheus metrics Will be stored in the ConfigMap |
 | cluster.monitoring.customQueriesSecret | list | `[]` | The list of secrets containing the custom queries |
@@ -292,11 +288,19 @@ Kubernetes: `>=1.29.0-0`
 | mode | string | `"standalone"` | Cluster mode of operation. Available modes: * `standalone` - default mode. Creates new or updates an existing CNPG cluster. * `replica` - Creates a replica cluster from an existing CNPG cluster. * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup. |
 | monitoring.grafanaDashboard.annotations | object | `{}` | Annotations that ConfigMaps can have to get configured in Grafana. |
 | monitoring.grafanaDashboard.configMapName | string | `"paradedb-grafana-dashboard"` | The name of the ConfigMap containing the dashboard. |
-| monitoring.grafanaDashboard.create | bool | `true` |  |
+| monitoring.grafanaDashboard.create | bool | `false` |  |
 | monitoring.grafanaDashboard.labels | object | `{"grafana_dashboard":"1"}` | Labels that ConfigMaps should have to get configured in Grafana. |
-| monitoring.grafanaDashboard.namespace | string | `"monitoring"` | Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release. |
+| monitoring.grafanaDashboard.namespace | string | `""` | Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release. |
 | nameOverride | string | `""` | Override the name of the chart |
 | namespaceOverride | string | `""` | Override the namespace of the chart |
+| networkPolicy | object | `{"allowedIngressCIDRs":[],"dnsNamespace":"kube-system","enabled":false,"externalEgress":{"enabled":true,"exceptCIDRs":["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]},"monitoringNamespace":"","operatorNamespace":"cnpg-system"}` | Default-deny NetworkPolicies for multi-tenant isolation. When enabled, the chart renders a default-deny policy plus the minimal allow-rules a ParadeDB CNPG cluster needs (intra-namespace, DNS, external egress, operator, monitoring, client CIDRs). Requires a NetworkPolicy-capable CNI. Off by default; meant for cells that co-tenant customers one-namespace-each (https://github.com/paradedb/cloud/issues/109). |
+| networkPolicy.allowedIngressCIDRs | list | `[]` | CIDRs allowed to connect to Postgres/PgBouncer on 5432 (e.g. load balancer / PrivateLink sources). Empty means intra-namespace clients only. |
+| networkPolicy.dnsNamespace | string | `"kube-system"` | Namespace running the cluster DNS service (CoreDNS/kube-dns); egress to it on port 53 is allowed. |
+| networkPolicy.enabled | bool | `false` | Render the default-deny + allow-rule NetworkPolicy set. |
+| networkPolicy.externalEgress.enabled | bool | `true` | Allow egress to external endpoints (object storage, cloud APIs, the internet) for backups and IRSA. |
+| networkPolicy.externalEgress.exceptCIDRs | list | `["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]` | On CNIs that give pods routable cluster IPs (e.g. the EKS VPC CNI), exclude the cluster's private ranges so cross-namespace pod egress stays denied while public endpoints stay reachable. |
+| networkPolicy.monitoringNamespace | string | `""` | Namespace running the metrics scraper; it is allowed to reach the metrics ports (9187, 9127). Empty disables the rule. |
+| networkPolicy.operatorNamespace | string | `"cnpg-system"` | Namespace running the CloudNativePG operator; it is allowed to reach the instances. Empty disables the rule. |
 | poolers | list | `[]` | List of PgBouncer poolers |
 | recovery.azure.connectionString | string | `""` |  |
 | recovery.azure.containerName | string | `""` |  |
@@ -338,8 +342,8 @@ Kubernetes: `>=1.29.0-0`
 | recovery.import.source.sslRootCertSecret.key | string | `""` |  |
 | recovery.import.source.sslRootCertSecret.name | string | `""` |  |
 | recovery.import.source.username | string | `""` |  |
-| recovery.import.type | string | `"microservice"` | One of `microservice` or `monolith`. See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works |
-| recovery.method | string | `"backup"` | Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster via a streaming replication protocol. Useful if you want to migrate databases to CloudNativePG, even from outside Kubernetes. * `import` - Import one or more databases from an existing Postgres cluster. |
+| recovery.import.type | string | `"microservice"` | One of `microservice` or `monolith` See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works |
+| recovery.method | string | `"backup"` | Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster via a streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. * `import` - Import one or more databases from an existing Postgres cluster. |
 | recovery.owner | string | `""` | Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key. |
 | recovery.pgBaseBackup.database | string | `"paradedb"` | Name of the database used by the application. Default: `paradedb`. |
 | recovery.pgBaseBackup.owner | string | `""` | Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key. |
@@ -402,8 +406,10 @@ Kubernetes: `>=1.29.0-0`
 | replica.origin.objectStore.secret.name | string | `""` | Name of the backup credentials secret |
 | replica.origin.pg_basebackup.database | string | `""` |  |
 | replica.origin.pg_basebackup.host | string | `""` |  |
+| replica.origin.pg_basebackup.passwordSecret.create | bool | `false` | Whether to create a secret for the password |
 | replica.origin.pg_basebackup.passwordSecret.key | string | `""` |  |
 | replica.origin.pg_basebackup.passwordSecret.name | string | `""` |  |
+| replica.origin.pg_basebackup.passwordSecret.value | string | `""` | The password value to use when creating the secret |
 | replica.origin.pg_basebackup.port | int | `5432` |  |
 | replica.origin.pg_basebackup.sslCertSecret.key | string | `""` |  |
 | replica.origin.pg_basebackup.sslCertSecret.name | string | `""` |  |
@@ -417,7 +423,7 @@ Kubernetes: `>=1.29.0-0`
 | replica.promotionToken | string | `""` | A demotion token generated by an external cluster used to check if the promotion requirements are met. |
 | replica.self | string | `""` | Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default. |
 | type | string | `"paradedb"` | Type of the CNPG database. Available types: * `paradedb` * `paradedb-enterprise` |
-| version.paradedb | string | `"0.24.0"` | We default to v0.24.0 for testing and local development |
+| version.paradedb | string | `"0.24.0"` | ParadeDB version to use |
 | version.postgresql | string | `"18"` | PostgreSQL major version to use |
 | poolers[].name | string | `` | Name of the pooler resource |
 | poolers[].instances | number | `1` | The number of replicas we want |

--- a/charts/paradedb/templates/networkpolicy.yaml
+++ b/charts/paradedb/templates/networkpolicy.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $fullname := include "cluster.fullname" . }}
+{{- $ns := include "cluster.namespace" . }}
+{{- $np := .Values.networkPolicy }}
+# Multi-tenant isolation for this cluster's namespace: a default-deny baseline plus the
+# minimal allow-rules a ParadeDB CNPG cluster needs (intra-namespace, DNS, external
+# egress for backups, operator, monitoring, and configured client CIDRs). Intended for
+# cells that co-tenant customers one-namespace-each. Requires a NetworkPolicy-capable CNI
+# (Calico, Cilium, or the EKS VPC CNI with its network policy agent). Off by default.
+# See https://github.com/paradedb/cloud/issues/109.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullname }}-default-deny
+  namespace: {{ $ns }}
+  labels:
+    {{- include "cluster.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Allow all traffic within the namespace (Postgres <-> replicas <-> PgBouncer).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullname }}-allow-intra-namespace
+  namespace: {{ $ns }}
+  labels:
+    {{- include "cluster.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+---
+# Egress: DNS resolution, plus (optionally) external endpoints for backups and IRSA.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullname }}-allow-egress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "cluster.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.dnsNamespace }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if $np.externalEgress.enabled }}
+    # External endpoints (object storage, cloud APIs, the internet) for Barman backups
+    # and IRSA. On CNIs that give pods routable cluster IPs (e.g. the EKS VPC CNI),
+    # exclude the cluster's private ranges so cross-namespace pod egress stays denied
+    # while public endpoints remain reachable.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            {{- with $np.externalEgress.exceptCIDRs }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+    {{- end }}
+{{- if or $np.operatorNamespace $np.monitoringNamespace $np.allowedIngressCIDRs }}
+---
+# Ingress: the operator, the metrics scraper, and configured external clients. Each rule
+# renders only when its source is configured; with none set, only intra-namespace ingress
+# (above) is allowed.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullname }}-allow-ingress
+  namespace: {{ $ns }}
+  labels:
+    {{- include "cluster.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- if $np.operatorNamespace }}
+    # CloudNativePG operator -> instances (status / lifecycle).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.operatorNamespace }}
+    {{- end }}
+    {{- if $np.monitoringNamespace }}
+    # Metrics scraper -> instance (9187) and pooler (9127) metrics endpoints.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $np.monitoringNamespace }}
+      ports:
+        - protocol: TCP
+          port: 9187
+        - protocol: TCP
+          port: 9127
+    {{- end }}
+    {{- if $np.allowedIngressCIDRs }}
+    # External clients (load balancer / PrivateLink sources) -> Postgres / PgBouncer.
+    - from:
+        {{- range $np.allowedIngressCIDRs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 5432
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/paradedb/values.schema.json
+++ b/charts/paradedb/values.schema.json
@@ -478,6 +478,37 @@
         "namespaceOverride": {
             "type": "string"
         },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "allowedIngressCIDRs": {
+                    "type": "array"
+                },
+                "dnsNamespace": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalEgress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "exceptCIDRs": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "monitoringNamespace": {
+                    "type": "string"
+                },
+                "operatorNamespace": {
+                    "type": "string"
+                }
+            }
+        },
         "poolers": {
             "type": "array"
         },

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -723,3 +723,28 @@ monitoring:
       grafana_dashboard: "1"
     # -- Annotations that ConfigMaps can have to get configured in Grafana.
     annotations: {}
+
+# -- Default-deny NetworkPolicies for multi-tenant isolation. When enabled, the chart
+# renders a default-deny policy plus the minimal allow-rules a ParadeDB CNPG cluster
+# needs (intra-namespace, DNS, external egress, operator, monitoring, client CIDRs).
+# Requires a NetworkPolicy-capable CNI. Off by default; meant for cells that co-tenant
+# customers one-namespace-each (https://github.com/paradedb/cloud/issues/109).
+networkPolicy:
+  # -- Render the default-deny + allow-rule NetworkPolicy set.
+  enabled: false
+  # -- Namespace running the cluster DNS service (CoreDNS/kube-dns); egress to it on port 53 is allowed.
+  dnsNamespace: kube-system
+  # -- Namespace running the CloudNativePG operator; it is allowed to reach the instances. Empty disables the rule.
+  operatorNamespace: cnpg-system
+  # -- Namespace running the metrics scraper; it is allowed to reach the metrics ports (9187, 9127). Empty disables the rule.
+  monitoringNamespace: ""
+  externalEgress:
+    # -- Allow egress to external endpoints (object storage, cloud APIs, the internet) for backups and IRSA.
+    enabled: true
+    # -- On CNIs that give pods routable cluster IPs (e.g. the EKS VPC CNI), exclude the cluster's private ranges so cross-namespace pod egress stays denied while public endpoints stay reachable.
+    exceptCIDRs:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+  # -- CIDRs allowed to connect to Postgres/PgBouncer on 5432 (e.g. load balancer / PrivateLink sources). Empty means intra-namespace clients only.
+  allowedIngressCIDRs: []


### PR DESCRIPTION
Adds an **opt-in** NetworkPolicy set so a cell can co-tenant multiple customers, one namespace each, with real network isolation (today pod networking is allow-all, so one tenant can reach another's Postgres/PgBouncer). Design: paradedb/cloud#129 (umbrella paradedb/cloud#109).

## What it renders (`networkPolicy.enabled: true`, default `false`)

- **`-default-deny`** — denies all ingress + egress in the namespace (baseline).
- **`-allow-intra-namespace`** — Postgres ↔ replicas ↔ PgBouncer within the namespace.
- **`-allow-egress`** — DNS (to `dnsNamespace:53`), plus external endpoints (object storage / cloud APIs / internet) for Barman + IRSA when `externalEgress.enabled`. On CNIs that give pods routable cluster IPs (the **EKS VPC CNI**), egress is `0.0.0.0/0` **except** `externalEgress.exceptCIDRs` (the cluster's private ranges) — so public endpoints work while **cross-namespace pod egress stays denied**.
- **`-allow-ingress`** (only if a source is configured) — the CNPG operator (`operatorNamespace`), the metrics scraper (`monitoringNamespace` → 9187/9127), and external clients (`allowedIngressCIDRs` → 5432).

All knobs documented in `values.yaml`; defaults are conservative (operator allowed, monitoring/client off until set).

## Validation done
- `helm lint` clean; `helm template` renders nothing by default, the 4 policies when enabled, and the optional rules gate correctly.
- `values.schema.json` updated; Helm accepts the new values. README regenerated with `helm-docs`.

## ⚠️ Needs live validation before anyone enables it
NetworkPolicies are the classic way to silently break a cluster. The **shape** is right and it's off by default, but the exact allow-set should be confirmed against a running cluster — specifically: operator reconciliation (does the instance manager need more than namespace ingress?), the metrics scrape, Barman egress under the `exceptCIDRs` exclusion (interface VPC endpoints would be RFC1918 and need allowlisting), and client connectivity through the LB/PrivateLink path (`allowedIngressCIDRs`, possibly node CIDRs for health checks). ParadeDB Cloud's disposable staging cell is the intended test bed; it enables the VPC CNI policy agent in paradedb/cloud#128 and will flip `networkPolicy.enabled` on via its render layer.

## Note
`README.md` is `helm-docs`-generated and was slightly stale vs `values.yaml`; regenerating it corrected a few unrelated rows alongside the `networkPolicy` additions.