### PR TITLE
feat: add CNPGInstanceMetricsAbsent alert and runbook

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -4,8 +4,6 @@
 
 This alert fires when a running CloudNativePG instance has stopped exporting its `cnpg_*` collector metrics — the exporter is hung rather than restarting. It is built to ride out routine restarts, upgrades, drains and scale-downs, so when it fires the instance is up but its metrics are no longer being collected.
 
-The chart ships this as an `up == 0` rule with a 10-minute `for`, long enough that a normal restart resolves before it pages. (The managed-platform copy instead gates on `kube_pod_status_ready` from kube-state-metrics; either way the meaning is the same.)
-
 ## Impact
 
 The risk is what this hides. The lag, HA and replication alerts all read metrics from this exporter:
@@ -16,7 +14,7 @@ The risk is what this hides. The lag, HA and replication alerts all read metrics
 
 They are `expr > threshold` rules, so once the exporter goes silent there are no samples to evaluate and they never fire. While this alert is active, treat the other replication and HA alerts for this instance as blind.
 
-A hung exporter has previously coincided with a frozen standby: an `index_info` instrumentation query deadlocked on a replica, freezing WAL replay and the collector at the same time. Replication was stuck with no notification because the metric that measures it had stopped reporting.
+A hung exporter can coincide with a frozen standby, which is when replication is stuck with no notification because the metric that measures it had stopped reporting.
 
 ## Diagnosis
 
@@ -98,7 +96,6 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 ## Prevention
 
-- Avoid expensive or lock-taking functions in `.spec.monitoring` queries; prefer cheap, read-only `pg_stat_*` reads.
 - When this fires, audit whether other replication or HA alerts should have fired and were silenced.
 
 ## Quick Reference Commands

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -2,61 +2,49 @@
 
 ## Description
 
-The `CNPGInstanceMetricsAbsent` alert fires when a CloudNativePG instance is **Ready** according to Kubernetes but has **stopped exporting CloudNativePG collector metrics** (`cnpg_collector_up` and every other `cnpg_*` series produced by that pod), after having reported them within the previous hour.
+This alert fires when a CloudNativePG instance is `Ready` but has stopped exporting its `cnpg_*` collector metrics, after reporting them within the last hour. The pod is healthy, so this is not a restart, upgrade, drain or scale-down — the instance's metrics exporter is hung.
 
-The alert deliberately gates on pod readiness so it does *not* fire for routine churn:
-
-- A restarting, upgrading, draining, or scaling-down instance is either absent or `NotReady`, so it is excluded.
-- A pod that is `Ready` but silent is a running database instance whose **metrics exporter has gone dark** — a monitoring blind spot, not a maintenance event.
-
-Readiness is read from `kube-state-metrics` (`kube_pod_status_ready`), which is a *separate* exporter from the in-pod CNPG collector. That independence is the whole point: it stays healthy and keeps reporting even when the instance's own collector is wedged.
+Readiness comes from kube-state-metrics (`kube_pod_status_ready`), a separate exporter from the in-pod CNPG collector, so it keeps reporting even when the collector is stuck. This alert therefore requires kube-state-metrics to be present.
 
 ## Impact
 
-This alert is **critical because of what it hides, not what it directly breaks**.
+The risk is what this hides. The lag, HA and replication alerts all read metrics from this exporter:
 
-Most replication and health alerts evaluate metrics emitted by this exact exporter:
+- `CNPGClusterPhysicalReplicationLag*` → `cnpg_pg_replication_lag`
+- `CNPGClusterHA*` → `cnpg_pg_replication_streaming_replicas`, `cnpg_pg_replication_is_wal_receiver_up`
+- logical replication alerts → `cnpg_pg_stat_subscription_*`
 
-- `PhysicalReplicationLagHigh` / `PhysicalReplicationLagCritical` → `cnpg_pg_replication_lag`
-- `CNPGClusterHAWarning` / `CNPGClusterHACritical` → `cnpg_pg_replication_streaming_replicas`, `cnpg_pg_replication_is_wal_receiver_up`
-- Logical replication alerts → `cnpg_pg_stat_subscription_*`
+They are `expr > threshold` rules, so once the exporter goes silent there are no samples to evaluate and they never fire. While this alert is active, treat the other replication and HA alerts for this instance as blind.
 
-These are all `expr > threshold` rules. When the exporter goes silent there are **no samples to evaluate**, so the expression returns an empty result and the alert **never enters pending or firing** — no-data is silence, not a page. In other words, while this alert is firing you should assume the other replication/HA alerts for this instance are **blind and cannot be trusted**.
-
-A known real-world trigger: an instrumentation query (`paradedb.index_info`) deadlocked when run on a standby, which simultaneously **froze WAL replay on that standby** *and* **wedged the standby's metrics collector**. Replication was stuck for an extended period with no notification, precisely because the thing that measures replication lag had stopped reporting it.
+A hung exporter has previously coincided with a frozen standby: an `index_info` instrumentation query deadlocked on a replica, freezing WAL replay and the collector at the same time. Replication was stuck with no notification because the metric that measures it had stopped reporting.
 
 ## Diagnosis
 
-### Step 1: Identify the affected instance
+### Step 1: Confirm the pod is up
 
-The alert labels carry `customer`, `namespace`, `cluster`, and `pod`. Confirm the pod is genuinely up:
+The alert labels carry `namespace`, `cluster` and `pod`.
 
 ```bash
 kubectl get pods --namespace <namespace> -l "cnpg.io/podRole=instance" -o wide
 kubectl describe pod --namespace <namespace> <pod-name>
 ```
 
-If the pod is `Running` and `Ready`, this is a true positive: the instance is alive but blind.
+If the pod is `Running` and `Ready`, it is alive but blind.
 
-### Step 2: Check whether the metrics endpoint is responding
+### Step 2: Check the metrics endpoint
 
-The collector serves metrics on port `9187` at `/metrics`. A hung exporter will hang or time out here while the pod stays Ready:
+The collector serves `/metrics` on port `9187`. A hung exporter times out here while the pod stays Ready:
 
 ```bash
-# From inside the pod (curl may not be present; wget/psql checks below also work)
 kubectl exec --namespace <namespace> <pod-name> -- \
-  curl -sS --max-time 5 http://localhost:9187/metrics | head
-
-# Or port-forward and scrape from your workstation
-kubectl port-forward --namespace <namespace> pod/<pod-name> 9187:9187
-curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
+  curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
 ```
 
-A timeout / empty response confirms the collector is wedged.
+A timeout or empty response confirms the collector is stuck.
 
-### Step 3: Look for a blocked or deadlocked backend
+### Step 3: Look for a blocked backend
 
-The exporter runs SQL against the local instance. If a collector query is stuck (often on a standby, against recovery conflict or an instrumentation function), it shows up in `pg_stat_activity`:
+The exporter runs SQL on the local instance. A stuck collector query shows up in `pg_stat_activity`:
 
 ```bash
 kubectl exec --namespace <namespace> <pod-name> -- psql -c "
@@ -68,15 +56,9 @@ ORDER BY duration DESC NULLS LAST;
 "
 ```
 
-On a **standby**, also check for a replay-blocking recovery conflict, which is the signature of the historical incident:
+On a standby, check whether replay is actually frozen by looking from the primary:
 
 ```bash
-kubectl exec --namespace <namespace> <pod-name> -- psql -c "
-SELECT pid, wait_event_type, wait_event, now() - query_start AS duration, left(query,120)
-FROM pg_stat_activity
-WHERE backend_type = 'client backend' AND wait_event_type IS NOT NULL;
-"
-# Replay actually frozen? restart_lsn / replay position should be advancing on the primary:
 kubectl exec --namespace <namespace> services/<cluster_name>-rw -- psql -c "
 SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;
 "
@@ -93,21 +75,21 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 ## Mitigation
 
-1. **Unblock the stuck backend.** If a specific query is wedging the collector (or freezing replay on a standby), terminate it:
+1. Terminate the stuck backend found in Step 3:
 
    ```bash
    kubectl exec --namespace <namespace> <pod-name> -- psql -c "SELECT pg_terminate_backend(<pid>);"
    ```
 
-2. **Remove the offending instrumentation/custom query.** If the hang originates from a monitoring query (for example a ParadeDB `index_info` instrumentation that deadlocks on a replica), disable that instrumentation / custom query in the cluster's `.spec.monitoring` configuration until a fixed engine version is rolled out. Re-enable it after upgrading.
+2. If the hang comes from a monitoring query (for example the `index_info` instrumentation deadlocking on a replica), disable that instrumentation in the cluster's `.spec.monitoring` config until a fixed version is rolled out, then re-enable it after upgrading.
 
-3. **Restart the instance as a last resort.** If the backend cannot be cleared, recycle the pod. Start with a **standby**, never the primary, to avoid an unnecessary failover:
+3. As a last resort, recycle the pod. Start with a standby, never the primary, to avoid an unnecessary failover:
 
    ```bash
    kubectl delete pod --namespace <namespace> <replica-pod-name>
    ```
 
-4. **Confirm recovery.** The alert resolves once `cnpg_collector_up` is reported again for the pod. Verify the metric is flowing and that the previously-blinded replication/HA alerts are evaluating real data:
+4. The alert resolves once `cnpg_collector_up` is reported again. Confirm metrics are flowing:
 
    ```bash
    kubectl exec --namespace <namespace> <pod-name> -- \
@@ -116,35 +98,12 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 ## Prevention
 
-- Keep ParadeDB / CloudNativePG and any custom monitoring queries on versions known to be safe on **standbys**, not just primaries — exporter queries run on every instance, including replicas.
-- Avoid expensive or lock-taking functions in `.spec.monitoring` custom queries and instrumentation; prefer cheap, read-only `pg_stat_*` reads.
-- Treat this alert as a meta-monitor: when it fires, audit whether other replication/HA alerts should also have fired and were silenced.
-
-## Quick Reference Commands
-
-```bash
-# Is the pod actually up and Ready?
-kubectl get pods --namespace <namespace> -l "cnpg.io/podRole=instance" -o wide
-
-# Is the metrics endpoint responding?
-kubectl exec --namespace <namespace> <pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
-
-# What is the collector backend stuck on?
-kubectl exec --namespace <namespace> <pod-name> -- psql -c "
-SELECT pid, state, wait_event_type, wait_event, now() - query_start AS duration, left(query,120)
-FROM pg_stat_activity WHERE state <> 'idle' ORDER BY duration DESC NULLS LAST;"
-
-# Is replication actually frozen (run against the primary)?
-kubectl exec --namespace <namespace> services/<cluster_name>-rw -- psql -c "
-SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;"
-
-# Last-resort restart (standby first)
-kubectl delete pod --namespace <namespace> <replica-pod-name>
-```
+- Keep custom monitoring queries safe to run on standbys, not just primaries — exporter queries run on every instance.
+- Avoid expensive or lock-taking functions in `.spec.monitoring` queries; prefer cheap, read-only `pg_stat_*` reads.
+- When this fires, audit whether other replication or HA alerts should have fired and were silenced.
 
 ## When to Escalate
 
-- Contact support if:
-  - The metrics endpoint stays unresponsive after terminating stuck backends.
-  - `pg_stat_replication` on the primary shows replay is frozen for the affected standby (replication is stuck, not just unmonitored).
-  - The collector wedges repeatedly after restart, or recurs across instances — this suggests a systemic instrumentation/engine bug that needs a version fix.
+- The metrics endpoint stays unresponsive after terminating stuck backends.
+- `pg_stat_replication` on the primary shows replay frozen for the affected standby (replication is stuck, not just unmonitored).
+- The collector hangs repeatedly after restart or recurs across instances, suggesting a systemic instrumentation or engine bug.

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -1,0 +1,150 @@
+# CNPGInstanceMetricsAbsent
+
+## Description
+
+The `CNPGInstanceMetricsAbsent` alert fires when a CloudNativePG instance is **Ready** according to Kubernetes but has **stopped exporting CloudNativePG collector metrics** (`cnpg_collector_up` and every other `cnpg_*` series produced by that pod), after having reported them within the previous hour.
+
+The alert deliberately gates on pod readiness so it does *not* fire for routine churn:
+
+- A restarting, upgrading, draining, or scaling-down instance is either absent or `NotReady`, so it is excluded.
+- A pod that is `Ready` but silent is a running database instance whose **metrics exporter has gone dark** — a monitoring blind spot, not a maintenance event.
+
+Readiness is read from `kube-state-metrics` (`kube_pod_status_ready`), which is a *separate* exporter from the in-pod CNPG collector. That independence is the whole point: it stays healthy and keeps reporting even when the instance's own collector is wedged.
+
+## Impact
+
+This alert is **critical because of what it hides, not what it directly breaks**.
+
+Most replication and health alerts evaluate metrics emitted by this exact exporter:
+
+- `PhysicalReplicationLagHigh` / `PhysicalReplicationLagCritical` → `cnpg_pg_replication_lag`
+- `CNPGClusterHAWarning` / `CNPGClusterHACritical` → `cnpg_pg_replication_streaming_replicas`, `cnpg_pg_replication_is_wal_receiver_up`
+- Logical replication alerts → `cnpg_pg_stat_subscription_*`
+
+These are all `expr > threshold` rules. When the exporter goes silent there are **no samples to evaluate**, so the expression returns an empty result and the alert **never enters pending or firing** — no-data is silence, not a page. In other words, while this alert is firing you should assume the other replication/HA alerts for this instance are **blind and cannot be trusted**.
+
+A known real-world trigger: an instrumentation query (`paradedb.index_info`) deadlocked when run on a standby, which simultaneously **froze WAL replay on that standby** *and* **wedged the standby's metrics collector**. Replication was stuck for an extended period with no notification, precisely because the thing that measures replication lag had stopped reporting it.
+
+## Diagnosis
+
+### Step 1: Identify the affected instance
+
+The alert labels carry `customer`, `namespace`, `cluster`, and `pod`. Confirm the pod is genuinely up:
+
+```bash
+kubectl get pods --namespace <namespace> -l "cnpg.io/podRole=instance" -o wide
+kubectl describe pod --namespace <namespace> <pod-name>
+```
+
+If the pod is `Running` and `Ready`, this is a true positive: the instance is alive but blind.
+
+### Step 2: Check whether the metrics endpoint is responding
+
+The collector serves metrics on port `9187` at `/metrics`. A hung exporter will hang or time out here while the pod stays Ready:
+
+```bash
+# From inside the pod (curl may not be present; wget/psql checks below also work)
+kubectl exec --namespace <namespace> <pod-name> -- \
+  curl -sS --max-time 5 http://localhost:9187/metrics | head
+
+# Or port-forward and scrape from your workstation
+kubectl port-forward --namespace <namespace> pod/<pod-name> 9187:9187
+curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
+```
+
+A timeout / empty response confirms the collector is wedged.
+
+### Step 3: Look for a blocked or deadlocked backend
+
+The exporter runs SQL against the local instance. If a collector query is stuck (often on a standby, against recovery conflict or an instrumentation function), it shows up in `pg_stat_activity`:
+
+```bash
+kubectl exec --namespace <namespace> <pod-name> -- psql -c "
+SELECT pid, state, wait_event_type, wait_event,
+       now() - query_start AS duration, left(query, 120) AS query
+FROM pg_stat_activity
+WHERE state <> 'idle'
+ORDER BY duration DESC NULLS LAST;
+"
+```
+
+On a **standby**, also check for a replay-blocking recovery conflict, which is the signature of the historical incident:
+
+```bash
+kubectl exec --namespace <namespace> <pod-name> -- psql -c "
+SELECT pid, wait_event_type, wait_event, now() - query_start AS duration, left(query,120)
+FROM pg_stat_activity
+WHERE backend_type = 'client backend' AND wait_event_type IS NOT NULL;
+"
+# Replay actually frozen? restart_lsn / replay position should be advancing on the primary:
+kubectl exec --namespace <namespace> services/<cluster_name>-rw -- psql -c "
+SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;
+"
+```
+
+### Step 4: Inspect logs
+
+```bash
+kubectl logs --namespace <namespace> <pod-name> --tail=200
+kubectl logs --namespace cnpg-system -l "app.kubernetes.io/name=cloudnative-pg" --tail=200
+```
+
+Look for collector errors, statement timeouts, or recovery-conflict / deadlock messages.
+
+## Mitigation
+
+1. **Unblock the stuck backend.** If a specific query is wedging the collector (or freezing replay on a standby), terminate it:
+
+   ```bash
+   kubectl exec --namespace <namespace> <pod-name> -- psql -c "SELECT pg_terminate_backend(<pid>);"
+   ```
+
+2. **Remove the offending instrumentation/custom query.** If the hang originates from a monitoring query (for example a ParadeDB `index_info` instrumentation that deadlocks on a replica), disable that instrumentation / custom query in the cluster's `.spec.monitoring` configuration until a fixed engine version is rolled out. Re-enable it after upgrading.
+
+3. **Restart the instance as a last resort.** If the backend cannot be cleared, recycle the pod. Start with a **standby**, never the primary, to avoid an unnecessary failover:
+
+   ```bash
+   kubectl delete pod --namespace <namespace> <replica-pod-name>
+   ```
+
+4. **Confirm recovery.** The alert resolves once `cnpg_collector_up` is reported again for the pod. Verify the metric is flowing and that the previously-blinded replication/HA alerts are evaluating real data:
+
+   ```bash
+   kubectl exec --namespace <namespace> <pod-name> -- \
+     curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_up|cnpg_pg_replication_lag"
+   ```
+
+## Prevention
+
+- Keep ParadeDB / CloudNativePG and any custom monitoring queries on versions known to be safe on **standbys**, not just primaries — exporter queries run on every instance, including replicas.
+- Avoid expensive or lock-taking functions in `.spec.monitoring` custom queries and instrumentation; prefer cheap, read-only `pg_stat_*` reads.
+- Treat this alert as a meta-monitor: when it fires, audit whether other replication/HA alerts should also have fired and were silenced.
+
+## Quick Reference Commands
+
+```bash
+# Is the pod actually up and Ready?
+kubectl get pods --namespace <namespace> -l "cnpg.io/podRole=instance" -o wide
+
+# Is the metrics endpoint responding?
+kubectl exec --namespace <namespace> <pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
+
+# What is the collector backend stuck on?
+kubectl exec --namespace <namespace> <pod-name> -- psql -c "
+SELECT pid, state, wait_event_type, wait_event, now() - query_start AS duration, left(query,120)
+FROM pg_stat_activity WHERE state <> 'idle' ORDER BY duration DESC NULLS LAST;"
+
+# Is replication actually frozen (run against the primary)?
+kubectl exec --namespace <namespace> services/<cluster_name>-rw -- psql -c "
+SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;"
+
+# Last-resort restart (standby first)
+kubectl delete pod --namespace <namespace> <replica-pod-name>
+```
+
+## When to Escalate
+
+- Contact support if:
+  - The metrics endpoint stays unresponsive after terminating stuck backends.
+  - `pg_stat_replication` on the primary shows replay is frozen for the affected standby (replication is stuck, not just unmonitored).
+  - The collector wedges repeatedly after restart, or recurs across instances — this suggests a systemic instrumentation/engine bug that needs a version fix.

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -75,13 +75,13 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 ## Mitigation
 
-1. Terminate the stuck backend found in Step 3:
+1. Terminate the stuck backend found in Step 3, if applicable:
 
    ```bash
    kubectl exec --namespace <namespace> <pod-name> -- psql -c "SELECT pg_terminate_backend(<pid>);"
    ```
 
-2. If the hang comes from a monitoring query (for example the `index_info` instrumentation deadlocking on a replica), disable that instrumentation in the cluster's `.spec.monitoring` config until a fixed version is rolled out, then re-enable it after upgrading.
+2. If the hang comes from a monitoring query, disable that instrumentation in the cluster's `.spec.monitoring` config until a fixed version is rolled out, then re-enable it after upgrading.
 
 3. As a last resort, recycle the pod. Start with a standby, never the primary, to avoid an unnecessary failover:
 
@@ -98,7 +98,6 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 ## Prevention
 
-- Keep custom monitoring queries safe to run on standbys, not just primaries — exporter queries run on every instance.
 - Avoid expensive or lock-taking functions in `.spec.monitoring` queries; prefer cheap, read-only `pg_stat_*` reads.
 - When this fires, audit whether other replication or HA alerts should have fired and were silenced.
 

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-This alert fires when a CloudNativePG instance is `Ready` but has stopped exporting its `cnpg_*` collector metrics, after reporting them within the last hour. The pod is healthy, so this is not a restart, upgrade, drain or scale-down — the instance's metrics exporter is hung.
+This alert fires when a running CloudNativePG instance has stopped exporting its `cnpg_*` collector metrics — the exporter is hung rather than restarting. It is built to ride out routine restarts, upgrades, drains and scale-downs, so when it fires the instance is up but its metrics are no longer being collected.
 
-Readiness comes from kube-state-metrics (`kube_pod_status_ready`), a separate exporter from the in-pod CNPG collector, so it keeps reporting even when the collector is stuck. This alert therefore requires kube-state-metrics to be present.
+The chart ships this as an `up == 0` rule with a 10-minute `for`, long enough that a normal restart resolves before it pages. (The managed-platform copy instead gates on `kube_pod_status_ready` from kube-state-metrics; either way the meaning is the same.)
 
 ## Impact
 

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
@@ -73,7 +73,7 @@ kubectl logs --namespace cnpg-system -l "app.kubernetes.io/name=cloudnative-pg" 
 
 Look for collector errors, statement timeouts, or recovery-conflict / deadlock messages.
 
-## Mitigation
+## Resolution
 
 1. Terminate the stuck backend found in Step 3, if applicable:
 
@@ -100,6 +100,28 @@ Look for collector errors, statement timeouts, or recovery-conflict / deadlock m
 
 - Avoid expensive or lock-taking functions in `.spec.monitoring` queries; prefer cheap, read-only `pg_stat_*` reads.
 - When this fires, audit whether other replication or HA alerts should have fired and were silenced.
+
+## Quick Reference Commands
+
+```bash
+# Is the pod up and Ready?
+kubectl get pods --namespace <namespace> -l "cnpg.io/podRole=instance" -o wide
+
+# Is the metrics endpoint responding?
+kubectl exec --namespace <namespace> <pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_collector_up
+
+# What is the collector backend stuck on?
+kubectl exec --namespace <namespace> <pod-name> -- psql -c "
+SELECT pid, state, wait_event_type, wait_event, now() - query_start AS duration, left(query,120)
+FROM pg_stat_activity WHERE state <> 'idle' ORDER BY duration DESC NULLS LAST;"
+
+# Is replication actually frozen (run against the primary)?
+kubectl exec --namespace <namespace> services/<cluster_name>-rw -- psql -c "
+SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;"
+
+# Last-resort restart (standby first)
+kubectl delete pod --namespace <namespace> <replica-pod-name>
+```
 
 ## When to Escalate
 

--- a/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
@@ -4,20 +4,13 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB CNPG metrics exporter hung
   description: |-
-    ParadeDB CNPG instance "{{ .namespace }}/{{ .labels.pod }}" is Ready but stopped exporting the metrics it was reporting an hour ago, so its metrics exporter is hung.
+    ParadeDB CNPG instance "{{ .namespace }}/{{ .labels.pod }}" has had an unreachable metrics endpoint for 10 minutes, so its metrics exporter is hung.
 
     The lag, HA and replication alerts all read from this exporter and will not fire while it is down. A hung exporter has previously coincided with a frozen standby, so physical replication may be stuck and unmonitored. Check the instance directly.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
 expr: |
-  (
-    count by (namespace, pod) (count_over_time(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[1h]))
-    unless
-    count by (namespace, pod) (cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"})
-  )
-  and on (namespace, pod) (
-    kube_pod_status_ready{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}",condition="true"} == 1
-  )
-for: 5m
+  up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 0
+for: 10m
 labels:
   severity: critical
   namespace: {{ .namespace }}

--- a/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
@@ -1,0 +1,25 @@
+{{- $alert := "CNPGInstanceMetricsAbsent" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: ParadeDB CNPG metrics exporter hung
+  description: |-
+    ParadeDB CNPG instance "{{ .namespace }}/{{ .labels.pod }}" is Ready but stopped exporting the metrics it was reporting an hour ago, so its metrics exporter is hung.
+
+    The lag, HA and replication alerts all read from this exporter and will not fire while it is down. A hung exporter has previously coincided with a frozen standby, so physical replication may be stuck and unmonitored. Check the instance directly.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
+expr: |
+  (
+    count by (namespace, pod) (count_over_time(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[1h]))
+    unless
+    count by (namespace, pod) (cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"})
+  )
+  and on (namespace, pod) (
+    kube_pod_status_ready{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}",condition="true"} == 1
+  )
+for: 5m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}


### PR DESCRIPTION
## Why

Ships the `CNPGInstanceMetricsAbsent` alert (and its runbook) that detects a CNPG instance whose **metrics exporter is hung** — it stops serving `cnpg_*` metrics while the instance is still running. The motivating incident: an `index_info` instrumentation query deadlocked on a standby, freezing WAL replay *and* the metrics collector at once, so the lag/HA alerts (which read from that same exporter) had no samples and silently never fired. The companion MCC VMRule is paradedb/mcc#128.

## What

- **`prometheus_rules/cluster-instance_metrics_absent.yaml`** — the alert, in the same Helm-templated form as the other rules (`$alert`/`excludeRules` guard, scoped by `.namespace`/`.podSelector`):

  ```yaml
  expr: |
    up{namespace="...",pod=~"...-([1-9][0-9]*)$"} == 0
  for: 10m
  ```

  A hung exporter makes the scrape time out, so `up` goes to `0`. `for: 10m` rides out normal restarts/upgrades; a removed pod's `up` series goes stale (not `0`), so scale-downs self-exclude.
- **`docs/runbooks/CNPGInstanceMetricsAbsent.md`** — diagnosis (is the pod up? is `/metrics` responding? what backend is stuck?) and resolution.

## No extra dependencies

`up` is synthesized by the scraper for every PodMonitor target, so this needs nothing beyond the monitoring already required for the other rules — no kube-state-metrics. (The MCC copy gates on `kube_pod_status_ready` instead, since KSM is guaranteed there and it scopes more surgically to "Ready but blind"; the chart deliberately avoids that dependency.)

## Note on scope

The chart rule pages on "metrics target unreachable for 10m," which also covers a crashlooping instance (some overlap with `CNPGClusterOffline`/HA — reasonable to know about) and would fire if a restart genuinely ran past 10 minutes. Tunable via `for` / `excludeRules`.

## Test plan

- [x] `helm template charts/paradedb --set cluster.monitoring.enabled=true --set cluster.monitoring.prometheusRule.enabled=true` renders the rule (`{{ $labels.pod }}` preserved for Prometheus; namespace/podSelector filled in).
- [x] Existing monitoring chainsaw assert still matches (it checks the PrometheusRule resource, not individual rules).