### PR TITLE
feat: Add serviceTemplate passthrough to the Pooler template

### DIFF
--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -427,7 +427,7 @@ Kubernetes: `>=1.29.0-0`
 | poolers[].authQuery | string | `{}` | The credentials of the user that need to be used for the authentication query. |
 | poolers[].parameters | map[string]string | `{}` | Additional parameters to be passed to PgBouncer - please check the CNPG documentation for a list of options you can configure |
 | poolers[].template | [PodTemplateSpec][PodTemplateSpec] | `{}` | The template of the Pod to be created |
-| poolers[].template | [ServiceTemplateSpec][ServiceTemplateSpec] | `{}` | Template for the Service to be created |
+| poolers[].serviceTemplate | [ServiceTemplateSpec][ServiceTemplateSpec] | `{}` | Template for the Service the pooler creates |
 | poolers[].pg_hba | []string | `{}` | PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file) |
 | poolers[].monitoring.enabled | bool | `false` | Whether to enable monitoring for the Pooler. |
 | poolers[].monitoring.podMonitor.enabled | bool | `true` | Create a podMonitor for the Pooler. |

--- a/charts/paradedb/templates/pooler.yaml
+++ b/charts/paradedb/templates/pooler.yaml
@@ -32,4 +32,8 @@ spec:
   template:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+  {{- with .serviceTemplate }}
+  serviceTemplate:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/paradedb/test/pooler/01-pooler_cluster-assert.yaml
+++ b/charts/paradedb/test/pooler/01-pooler_cluster-assert.yaml
@@ -23,6 +23,10 @@ spec:
   pgbouncer:
     poolMode: transaction
   type: rw
+  serviceTemplate:
+    metadata:
+      labels:
+        cnpg.io/pooler-service: "true"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: Pooler

--- a/charts/paradedb/test/pooler/01-pooler_cluster.yaml
+++ b/charts/paradedb/test/pooler/01-pooler_cluster.yaml
@@ -12,6 +12,10 @@ poolers:
     type: rw
     instances: 2
     poolMode: transaction
+    serviceTemplate:
+      metadata:
+        labels:
+          cnpg.io/pooler-service: "true"
   - name: ro
     type: ro
     instances: 2

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -679,6 +679,9 @@ poolers: []
   #   # -- Custom PgBouncer deployment template.
   #   # Use to override image, specify resources, etc.
   #   template: {}
+  #   # -- Template for the Service the pooler creates.
+  #   # Use to expose the pooler as a LoadBalancer, set annotations, etc.
+  #   serviceTemplate: {}
   # -
   #   # -- Pooler name
   #   name: ro
@@ -710,6 +713,9 @@ poolers: []
   #   # -- Custom PgBouncer deployment template.
   #   # Use to override image, specify resources, etc.
   #   template: {}
+  #   # -- Template for the Service the pooler creates.
+  #   # Use to expose the pooler as a LoadBalancer, set annotations, etc.
+  #   serviceTemplate: {}
 
 monitoring:
   grafanaDashboard:


### PR DESCRIPTION
## What

Adds `serviceTemplate` passthrough to the Pooler template so a pooler's Service can be customized from chart values (type, annotations, labels), the same way `template` already customizes the pgbouncer deployment.

Before, `templates/pooler.yaml` only rendered `.template`:

```yaml
{{- with .template }}
template:
  {{- . | toYaml | nindent 4 }}
{{- end }}
```

CNPG's Pooler spec supports `serviceTemplate` at the same level, but the chart never exposed it, so the pooler Service was always ClusterIP with no way to override it.

## Why

In `paradedb/cloud`, every customer cluster is expressed as chart values (`customer.rs` -> `chart.rs` -> Helm values), not as out-of-band Terraform. To front the pooler with an internal NLB for AWS PrivateLink, the chart needs to render the pooler's Service as a `LoadBalancer` with the AWS LB annotations. That is not possible today without this passthrough.

This is the "charts work first" step called out in paradedb/cloud#13.

## Changes

- `templates/pooler.yaml`: pass `serviceTemplate` through when set.
- `values.yaml`: document the new field in the poolers example block.
- `test/pooler`: set a `serviceTemplate` on the rw pooler and assert it lands on the rendered Pooler CR.

## Testing

`helm template` renders `serviceTemplate` for the rw pooler and omits it for the ro pooler (none set). `helm lint` passes.

https://claude.ai/code/session_01RVg7zztPzKfJvEGwo12dUb