### PR TITLE
fix(paradedb): tidy rendered postgresql.parameters whitespace

### DIFF
--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -98,12 +98,12 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{ end }}
     parameters:
-      {{ if eq .Values.type "paradedb-enterprise" }}
+      {{- if eq .Values.type "paradedb-enterprise" }}
       hot_standby_feedback: "1"
-      {{ end }}
+      {{- end }}
       {{- with .Values.cluster.postgresql.parameters }}
-      {{ toYaml . | nindent 6 }}
-      {{ end }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       cron.database_name: postgres
 
   {{- with .Values.cluster.replicationSlots }}


### PR DESCRIPTION
Tidies stray whitespace in the rendered `postgresql.parameters` map. Addresses item 1 of paradedb/cloud#127.

The chart merged its default params (`hot_standby_feedback`, `cron.database_name`) with the customer's via Go-template blocks that didn't trim newlines, so the rendered `Cluster` had blank lines scattered through the `parameters:` map. Harmless (YAML ignores blank lines in a mapping) but noisy in `helm diff` plans. Tightened the whitespace control with `{{- … }}`.

**Before** (enterprise + two custom params):
```yaml
    parameters:

      hot_standby_feedback: "1"


      max_connections: "200"
      work_mem: 32MB

      cron.database_name: postgres
```

**After:**
```yaml
    parameters:
      hot_standby_feedback: "1"
      max_connections: "200"
      work_mem: 32MB
      cron.database_name: postgres
```

Verified across all three cases (paradedb / paradedb-enterprise / with & without custom params) — no blank lines, correct content in each. `helm lint` passes.

> Item 2 of the issue (the `-paradedb` fullname suffix) is intentionally **not** included here — see the explanation on paradedb/cloud#127.

Refs paradedb/cloud#127

https://claude.ai/code/session_01S4qVizyPzUqmXg2dcwqMxZ