### PR TITLE
fix: dashboard incorrect maintenance_work_mem

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5951,7 +5951,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"}",
+          "expr": "cnpg_pg_settings_setting{name=\"maintenance_work_mem\",namespace=~\"$namespace\",pod=~\"$instances\"} * 1024",
           "instant": true,
           "interval": "",
           "legendFormat": "{{pod}}",


### PR DESCRIPTION
Fixes the `Maintenance Work Mem` panel having an incorrect value, as the reported value from the metrics is in `KiB`.
<img width="545" height="147" alt="image" src="https://github.com/user-attachments/assets/e28e6bcf-3c04-4ad0-9870-b7bd55321ae3" />
