### PR TITLE
chore: upgrade ParadeDB from 0.24.3 to 0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 
 cluster:
   instances: 1

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -27,8 +27,8 @@ type: application
 version: 0.0.0-generated-in-ci
 
 # The ParadeDB version, set in the publish CI workflow from the latest paradedb/paradedb GitHub tag
-# We default to v0.24.3 for testing and local development
-appVersion: 0.24.3
+# We default to v0.25.0 for testing and local development
+appVersion: 0.25.0
 
 sources:
   - https://github.com/paradedb/charts

--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -46,7 +46,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 
 cluster:
   instances: 1
@@ -422,7 +422,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | replica.self | string | `""` | Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default. |
 | subscriptions | list | `[]` | Declarative logical replication subscriptions (CNPG `Subscription` resources) |
 | type | string | `"paradedb"` | Type of the CNPG database. Available types: * `paradedb` * `paradedb-enterprise` |
-| version.paradedb | string | `"0.24.3"` | ParadeDB version to use |
+| version.paradedb | string | `"0.25.0"` | ParadeDB version to use |
 | version.postgresql | string | `"18"` | PostgreSQL major version to use |
 | poolers[].name | string | `` | Name of the pooler resource |
 | poolers[].instances | number | `1` | The number of replicas we want |

--- a/charts/paradedb/README.md.gotmpl
+++ b/charts/paradedb/README.md.gotmpl
@@ -46,7 +46,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 
 cluster:
   instances: 1

--- a/charts/paradedb/examples/image-catalog-ref.yaml
+++ b/charts/paradedb/examples/image-catalog-ref.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   imageCatalogRef:

--- a/charts/paradedb/examples/image-catalog.yaml
+++ b/charts/paradedb/examples/image-catalog.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
 backups:

--- a/charts/paradedb/examples/paradedb.yaml
+++ b/charts/paradedb/examples/paradedb.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   postgresql: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
 backups:

--- a/charts/paradedb/templates/_bootstrap.tpl
+++ b/charts/paradedb/templates/_bootstrap.tpl
@@ -22,9 +22,9 @@ bootstrap:
     {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") (not (empty .Values.cluster.initdb.postInitApplicationSQL)) }}
     postInitApplicationSQL:
       {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") }}
+      - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS pg_search;
       - CREATE EXTENSION IF NOT EXISTS pg_ivm;
-      - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS postgis;
       - CREATE EXTENSION IF NOT EXISTS postgis_topology;
       - CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
@@ -43,9 +43,9 @@ bootstrap:
     {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") (not (empty .Values.cluster.initdb.postInitTemplateSQL)) }}
     postInitTemplateSQL:
       {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") }}
+      - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS pg_search;
       - CREATE EXTENSION IF NOT EXISTS pg_ivm;
-      - CREATE EXTENSION IF NOT EXISTS vector;
       - CREATE EXTENSION IF NOT EXISTS postgis;
       - CREATE EXTENSION IF NOT EXISTS postgis_topology;
       - CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
@@ -95,9 +95,9 @@ bootstrap:
       {{- end }}
       postImportApplicationSQL:
         {{- if or (eq .Values.type "paradedb") (eq .Values.type "paradedb-enterprise") }}
+        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS pg_search;
         - CREATE EXTENSION IF NOT EXISTS pg_ivm;
-        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS postgis;
         - CREATE EXTENSION IF NOT EXISTS postgis_topology;
         - CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;

--- a/charts/paradedb/test/console-statefulset/01-console_test_cluster.yaml
+++ b/charts/paradedb/test/console-statefulset/01-console_test_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   postgresql: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   console:

--- a/charts/paradedb/test/paradedb-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
+++ b/charts/paradedb/test/paradedb-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
@@ -52,9 +52,9 @@ spec:
       secret:
         name: mydb-secret
       postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS pg_search;
         - CREATE EXTENSION IF NOT EXISTS pg_ivm;
-        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS postgis;
         - CREATE EXTENSION IF NOT EXISTS postgis_topology;
         - CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
@@ -63,9 +63,9 @@ spec:
         - ALTER DATABASE "mydb" SET search_path TO public,paradedb;
         - CREATE TABLE mytable (id serial PRIMARY KEY, name VARCHAR(255));
       postInitTemplateSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS pg_search;
         - CREATE EXTENSION IF NOT EXISTS pg_ivm;
-        - CREATE EXTENSION IF NOT EXISTS vector;
         - CREATE EXTENSION IF NOT EXISTS postgis;
         - CREATE EXTENSION IF NOT EXISTS postgis_topology;
         - CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;

--- a/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
+++ b/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 2
   storage:

--- a/charts/paradedb/test/paradedb-minio-backup-restore/01-paradedb_cluster.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/01-paradedb_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 2
   storage:

--- a/charts/paradedb/test/replica/01-source_cluster_enterprise.yaml
+++ b/charts/paradedb/test/replica/01-source_cluster_enterprise.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/scheduledbackups/01-scheduledbackups_cluster.yaml
+++ b/charts/paradedb/test/scheduledbackups/01-scheduledbackups_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -14,7 +14,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.24.3"
+  paradedb: "0.25.0"
 
 # -- Cluster mode of operation. Available modes:
 # * `standalone` - default mode. Creates new or updates an existing CNPG cluster.
@@ -633,7 +633,7 @@ databases: []
  #   extensions: []                 # -- List of extensions to be created in the database.
  #    # - name: pg_search
  #    #   ensure: present           # -- Ensure the PostgreSQL extension is present or absent - defaults to "present".
- #    #   version: "0.24.3"         # -- Version of the extension to be installed, if not specified the latest version will be used.
+ #    #   version: "0.25.0"         # -- Version of the extension to be installed, if not specified the latest version will be used.
  #    #   schema: ""                # -- Schema where the extension will be installed, if not specified the extensions or current default object creation schema will be used.
  #   isTemplate: false              # -- Maps to the IS_TEMPLATE parameter. If true, the database is considered a template for new databases.
  #   locale: ""                     # -- Maps to the LC_COLLATE and LC_CTYPE parameters


### PR DESCRIPTION
## What

Bumps the default ParadeDB version from `0.24.3` to `0.25.0`, and fixes the extension bootstrap order that 0.25.0 requires.

Version bump:
- `charts/paradedb/Chart.yaml` (`appVersion` + comment)
- `charts/paradedb/values.yaml` (`version.paradedb`, and the `pg_search` extension version example)
- `README.md`, `charts/paradedb/README.md`, `charts/paradedb/README.md.gotmpl`
- `charts/paradedb/examples/*`
- `charts/paradedb/test/*` chainsaw cluster manifests

Bootstrap fix:
- `pg_search` 0.25.0 declares `requires = 'vector'` in its control file ([paradedb#5714](https://github.com/paradedb/paradedb/pull/5714), native vector search). `CREATE EXTENSION pg_search` therefore fails with `required extension "vector" is not installed` unless pgvector already exists in the database, which broke initdb on every cluster.
- Moved `CREATE EXTENSION IF NOT EXISTS vector;` ahead of `pg_search` in `postInitApplicationSQL`, `postInitTemplateSQL` and `postImportApplicationSQL` in `templates/_bootstrap.tpl`, and updated the `paradedb-cluster-configuration` assert accordingly.

## Testing

- `helm lint charts/paradedb` passes
- All 13 chainsaw suites pass in CI (they were failing on the version bump alone with the initdb error above)

https://claude.ai/code/session_01F5jGm114h6HAssAMiEcixp