### PR TITLE
docs: add the four missing CNPG alert runbooks

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
+++ b/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `CNPGBackupFailed` alert is triggered when a CloudNativePG cluster's most recent backup attempt failed. Specifically, when the cluster's `lastFailedBackup` is more recent than its `lastSuccessfulBackup` or when a failure exists and there has never been a successful backup at all. The alert clears on its own once a backup succeeds.
+The `CNPGBackupFailed` alert is triggered when a CloudNativePG cluster's most recent backup attempt failed, meaning its `lastFailedBackup` is more recent than its `lastSuccessfulBackup`, or a failure exists and there has never been a successful backup at all. The alert clears on its own once a backup succeeds.
 
 ## Impact
 
@@ -12,32 +12,34 @@ A single failed nightly run is usually not urgent on its own. It becomes urgent 
 
 ## Diagnosis
 
-Find the failed Backup object and read its error:
+- Find the failed Backup object and read its error, which is usually in `.status.error`:
 
-kubectl get backups.postgresql.cnpg.io -n <namespace> \
-  --sort-by=.status.startedAt -o wide | tail
-
-kubectl describe backups.postgresql.cnpg.io -n <namespace> <backup>
+```bash
+kubectl get -n <namespace> backups --sort-by=.status.startedAt -o wide | tail
+kubectl describe -n <namespace> backup/<backup-name>
 ```
 
-The failure reason is usually in `.status.error`. Common causes, roughly in order of likelihood:
+- Check the instance logs for the backup window:
 
-- **Object store credentials** — expired, rotated, or an IAM role that lost a permission.
-- **Bucket access** — the bucket was moved, renamed, or its policy changed.
-- **Disk pressure on the instance taking the backup** — check whether `CNPGClusterLowDiskSpaceWarning` is also firing.
-- **The instance being backed up was unavailable** when the run started.
-
-Check the instance logs for the backup window:
-
-kubectl logs -n <namespace> <cluster>-N -c postgres --since=24h | grep -i backup
+```bash
+kubectl logs -n <namespace> pod/<instance-pod-name> -c postgres --since=24h | grep -i backup
 ```
+
+Common causes:
+
+- Object store credentials that expired, were rotated, or lost a permission on the IAM role
+- Bucket access, where the bucket was moved or renamed, or its policy changed
+- Disk pressure on the instance taking the backup, in which case `CNPGClusterLowDiskSpace` is usually firing too
+- The instance being backed up was unavailable when the run started
 
 ## Mitigation
 
 Fix the underlying cause, then trigger a backup rather than waiting for the next scheduled run:
 
-```sh
-kubectl cnpg backup <cluster> -n <namespace>
+```bash
+kubectl cnpg backup paradedb -n <namespace>
 ```
 
-If credentials were the cause, verify the fix end to end rather than assuming since a corrected secret that was never reloaded will fail again at the next run, quietly, until this alert fires a second time.
+If credentials were the cause, verify the fix end to end rather than assuming. A corrected secret that was never reloaded fails again at the next run, quietly, until this alert fires a second time.
+
+If backups are succeeding but the recovery point is still frozen, WAL archiving rather than the base backup is the problem. See the [`CNPGContinuousArchivingFailed`](./CNPGContinuousArchivingFailed.md) runbook.

--- a/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
+++ b/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
@@ -2,23 +2,18 @@
 
 ## Description
 
-The `CNPGBackupFailed` alert is triggered when a CloudNativePG cluster's most recent backup attempt failed. Specifically, when the cluster's `lastFailedBackup` is more recent than its `lastSuccessfulBackup` — or when a failure exists and there has never been a successful backup at all.
-
-The second case matters more than it looks. A cluster whose backups have *never* worked has no successful timestamp to compare against, so a naive "failed more recently than succeeded" test would stay silent on the cluster with no backups whatsoever.
-
-The alert clears on its own once a backup succeeds, because a newer success moves the comparison back the other way. It does not need acknowledging or resolving by hand.
+The `CNPGBackupFailed` alert is triggered when a CloudNativePG cluster's most recent backup attempt failed. Specifically, when the cluster's `lastFailedBackup` is more recent than its `lastSuccessfulBackup` or when a failure exists and there has never been a successful backup at all. The alert clears on its own once a backup succeeds.
 
 ## Impact
 
 The newest restorable copy is older than it should be, and the recovery window stops advancing for as long as the failures continue.
 
-A single failed nightly run is usually not urgent on its own — the previous night's backup is still valid. It becomes urgent when it repeats, which is why `CNPGBackupStale` exists as the critical backstop at 26 hours.
+A single failed nightly run is usually not urgent on its own. It becomes urgent when it repeats, which is why `CNPGBackupStale` exists as the critical backstop at 26 hours.
 
 ## Diagnosis
 
 Find the failed Backup object and read its error:
 
-```sh
 kubectl get backups.postgresql.cnpg.io -n <namespace> \
   --sort-by=.status.startedAt -o wide | tail
 
@@ -34,16 +29,15 @@ The failure reason is usually in `.status.error`. Common causes, roughly in orde
 
 Check the instance logs for the backup window:
 
-```sh
 kubectl logs -n <namespace> <cluster>-N -c postgres --since=24h | grep -i backup
 ```
 
 ## Mitigation
 
-Fix the underlying cause, then trigger a backup rather than waiting for the next scheduled run — that both confirms the fix and clears the alert:
+Fix the underlying cause, then trigger a backup rather than waiting for the next scheduled run:
 
 ```sh
 kubectl cnpg backup <cluster> -n <namespace>
 ```
 
-If credentials were the cause, verify the fix end to end rather than assuming: a corrected secret that was never reloaded will fail again at the next run, quietly, until this alert fires a second time.
+If credentials were the cause, verify the fix end to end rather than assuming since a corrected secret that was never reloaded will fail again at the next run, quietly, until this alert fires a second time.

--- a/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
+++ b/charts/paradedb/docs/runbooks/CNPGBackupFailed.md
@@ -1,0 +1,49 @@
+# CNPGBackupFailed
+
+## Description
+
+The `CNPGBackupFailed` alert is triggered when a CloudNativePG cluster's most recent backup attempt failed. Specifically, when the cluster's `lastFailedBackup` is more recent than its `lastSuccessfulBackup` — or when a failure exists and there has never been a successful backup at all.
+
+The second case matters more than it looks. A cluster whose backups have *never* worked has no successful timestamp to compare against, so a naive "failed more recently than succeeded" test would stay silent on the cluster with no backups whatsoever.
+
+The alert clears on its own once a backup succeeds, because a newer success moves the comparison back the other way. It does not need acknowledging or resolving by hand.
+
+## Impact
+
+The newest restorable copy is older than it should be, and the recovery window stops advancing for as long as the failures continue.
+
+A single failed nightly run is usually not urgent on its own — the previous night's backup is still valid. It becomes urgent when it repeats, which is why `CNPGBackupStale` exists as the critical backstop at 26 hours.
+
+## Diagnosis
+
+Find the failed Backup object and read its error:
+
+```sh
+kubectl get backups.postgresql.cnpg.io -n <namespace> \
+  --sort-by=.status.startedAt -o wide | tail
+
+kubectl describe backups.postgresql.cnpg.io -n <namespace> <backup>
+```
+
+The failure reason is usually in `.status.error`. Common causes, roughly in order of likelihood:
+
+- **Object store credentials** — expired, rotated, or an IAM role that lost a permission.
+- **Bucket access** — the bucket was moved, renamed, or its policy changed.
+- **Disk pressure on the instance taking the backup** — check whether `CNPGClusterLowDiskSpaceWarning` is also firing.
+- **The instance being backed up was unavailable** when the run started.
+
+Check the instance logs for the backup window:
+
+```sh
+kubectl logs -n <namespace> <cluster>-N -c postgres --since=24h | grep -i backup
+```
+
+## Mitigation
+
+Fix the underlying cause, then trigger a backup rather than waiting for the next scheduled run — that both confirms the fix and clears the alert:
+
+```sh
+kubectl cnpg backup <cluster> -n <namespace>
+```
+
+If credentials were the cause, verify the fix end to end rather than assuming: a corrected secret that was never reloaded will fail again at the next run, quietly, until this alert fires a second time.

--- a/charts/paradedb/docs/runbooks/CNPGBackupStale.md
+++ b/charts/paradedb/docs/runbooks/CNPGBackupStale.md
@@ -1,0 +1,57 @@
+# CNPGBackupStale
+
+## Description
+
+The `CNPGBackupStale` alert is triggered when a CloudNativePG cluster's most recent **successful** backup is more than 26 hours old.
+
+Backups are scheduled nightly, so 26 hours is one missed run plus two hours of grace. The alert deliberately does not care *why* the backup is old: it fires whether backups have been failing, whether the ScheduledBackup stopped being reconciled, or whether backups were switched off and nobody noticed.
+
+This is the only backup alert that fires when backups stop happening **silently**. `CNPGBackupFailed` needs a failure to report, and a backup that is never attempted never fails.
+
+## Impact
+
+Everything written since the last successful backup is outside the recovery window.
+
+If the cluster is lost while this alert is firing, recovery goes back to the timestamp in the alert body rather than to the last nightly run. The gap grows for as long as the condition persists.
+
+Note that continuous WAL archiving, where enabled, may still allow point-in-time recovery past the last base backup. Check whether WAL archiving is healthy before assuming the full window is lost.
+
+## Diagnosis
+
+Find the cluster's recorded backup timestamps:
+
+```sh
+kubectl get cluster -n <namespace> <cluster> \
+  -o jsonpath='{.status.lastSuccessfulBackupByMethod}{"\n"}{.status.lastFailedBackup}{"\n"}'
+```
+
+List recent Backup objects and their phases:
+
+```sh
+kubectl get backups.postgresql.cnpg.io -n <namespace> \
+  --sort-by=.status.startedAt -o wide
+```
+
+Then work out which of the three cases applies:
+
+- **Backups are failing** — recent Backup objects exist in a failed phase. `CNPGBackupFailed` should also be firing; treat that as the primary alert.
+- **Backups are not being attempted** — no recent Backup objects at all. Check the ScheduledBackup; `CNPGScheduledBackupStalled` covers the case where the operator has stopped advancing the schedule.
+- **Backups are not configured** — the cluster has no `backup` section, or no ScheduledBackup exists. The timestamp is then a leftover from whenever backups were last enabled.
+
+## Mitigation
+
+If backups are failing, fix the underlying failure — see `CNPGBackupFailed`.
+
+If nothing is being attempted, confirm a ScheduledBackup exists and is being reconciled:
+
+```sh
+kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> -o wide
+```
+
+To close the recovery gap immediately rather than waiting for the next scheduled run, trigger a backup by hand:
+
+```sh
+kubectl cnpg backup <cluster> -n <namespace>
+```
+
+If the cluster is genuinely not meant to be backed up, the alert is telling you the truth about a cluster it should not be watching. Scope the rule rather than silencing it, so the exemption is visible in code instead of living in a silence that outlives the person who created it.

--- a/charts/paradedb/docs/runbooks/CNPGBackupStale.md
+++ b/charts/paradedb/docs/runbooks/CNPGBackupStale.md
@@ -2,56 +2,52 @@
 
 ## Description
 
-The `CNPGBackupStale` alert is triggered when a CloudNativePG cluster's most recent **successful** backup is more than 26 hours old.
+The `CNPGBackupStale` alert is triggered when a CloudNativePG cluster's most recent successful backup is more than 26 hours old.
 
-Backups are scheduled nightly, so 26 hours is one missed run plus two hours of grace. The alert deliberately does not care *why* the backup is old: it fires whether backups have been failing, whether the ScheduledBackup stopped being reconciled, or whether backups were switched off and nobody noticed.
+Backups are scheduled nightly, so 26 hours is one missed run plus two hours of grace. The alert does not distinguish why the backup is old: it fires whether backups have been failing, whether the ScheduledBackup stopped being reconciled, or whether backups were switched off and nobody noticed.
 
-This is the only backup alert that fires when backups stop happening **silently**. `CNPGBackupFailed` needs a failure to report, and a backup that is never attempted never fails.
+This is the only backup alert that fires when backups stop happening silently. `CNPGBackupFailed` needs a failure to report, and a backup that is never attempted never fails.
 
 ## Impact
 
-Everything written since the last successful backup is outside the recovery window.
+Everything written since the last successful backup is outside the recovery window. If the cluster is lost while this alert is firing, recovery goes back to the timestamp in the alert body rather than to the last nightly run, and the gap grows for as long as the condition persists.
 
-If the cluster is lost while this alert is firing, recovery goes back to the timestamp in the alert body rather than to the last nightly run. The gap grows for as long as the condition persists.
-
-Note that continuous WAL archiving, where enabled, may still allow point-in-time recovery past the last base backup. Check whether WAL archiving is healthy before assuming the full window is lost.
+Where continuous WAL archiving is enabled, point-in-time recovery may still reach past the last base backup. Check that archiving is healthy before assuming the full window is lost, since the [`CNPGContinuousArchivingFailed`](./CNPGContinuousArchivingFailed.md) alert covers the case where it is not.
 
 ## Diagnosis
 
-Find the cluster's recorded backup timestamps:
+- Find the cluster's recorded backup timestamps:
 
-```sh
-kubectl get cluster -n <namespace> <cluster> \
-  -o jsonpath='{.status.lastSuccessfulBackupByMethod}{"\n"}{.status.lastFailedBackup}{"\n"}'
+```bash
+kubectl get -n <namespace> cluster/paradedb -o 'jsonpath={.status.lastSuccessfulBackupByMethod}{"\n"}{.status.lastFailedBackup}{"\n"}'
 ```
 
-List recent Backup objects and their phases:
+- List recent Backup objects and their phases:
 
-```sh
-kubectl get backups.postgresql.cnpg.io -n <namespace> \
-  --sort-by=.status.startedAt -o wide
+```bash
+kubectl get -n <namespace> backups --sort-by=.status.startedAt -o wide
 ```
 
-Then work out which of the three cases applies:
+Three cases produce this alert, and they need different responses:
 
-- **Backups are failing** — recent Backup objects exist in a failed phase. `CNPGBackupFailed` should also be firing; treat that as the primary alert.
-- **Backups are not being attempted** — no recent Backup objects at all. Check the ScheduledBackup; `CNPGScheduledBackupStalled` covers the case where the operator has stopped advancing the schedule.
-- **Backups are not configured** — the cluster has no `backup` section, or no ScheduledBackup exists. The timestamp is then a leftover from whenever backups were last enabled.
+- Backups are failing, so recent Backup objects exist in a failed phase. `CNPGBackupFailed` should also be firing; treat that as the primary alert.
+- Backups are not being attempted, so there are no recent Backup objects at all. Check the ScheduledBackup, and see [`CNPGScheduledBackupStalled`](./CNPGScheduledBackupStalled.md) for the case where the operator has stopped advancing the schedule.
+- Backups are not configured, so the cluster has no `backup` section or no ScheduledBackup exists. The timestamp is then a leftover from whenever backups were last enabled.
 
 ## Mitigation
 
-If backups are failing, fix the underlying failure — see `CNPGBackupFailed`.
+If backups are failing, fix the underlying failure. See the [`CNPGBackupFailed`](./CNPGBackupFailed.md) runbook.
 
 If nothing is being attempted, confirm a ScheduledBackup exists and is being reconciled:
 
-```sh
-kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> -o wide
+```bash
+kubectl get -n <namespace> scheduledbackups -o wide
 ```
 
 To close the recovery gap immediately rather than waiting for the next scheduled run, trigger a backup by hand:
 
-```sh
-kubectl cnpg backup <cluster> -n <namespace>
+```bash
+kubectl cnpg backup paradedb -n <namespace>
 ```
 
-If the cluster is genuinely not meant to be backed up, the alert is telling you the truth about a cluster it should not be watching. Scope the rule rather than silencing it, so the exemption is visible in code instead of living in a silence that outlives the person who created it.
+If the cluster is genuinely not meant to be backed up, the alert is reporting the truth about a cluster it should not be watching. Scope the rule rather than silencing it, so the exemption is visible in code instead of living in a silence that outlives whoever created it.

--- a/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
+++ b/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
@@ -62,6 +62,8 @@ WHERE state = 'active'
 "
 ```
 
+Terminating a backend is disruptive, and a query long enough to cause replication lag has usually tripped [`PostgreSQLLongRunningQueriesWarning`](./PostgreSQLLongRunningQueriesWarning.md) as well. That runbook covers which queries are safe to cancel and why `pg_cancel_backend` is preferred over terminating.
+
 - Increase the memory and CPU resources of the instances under heavy load. This can be done by setting `cluster.resources.requests` and `cluster.resources.limits` in your Helm values. Set both `requests` and `limits` to the same value to achieve QoS Guaranteed. This will require a restart of the CloudNativePG cluster instances and a primary switchover, which will cause a brief service disruption.
 
 - Enable `wal_compression` by setting the `cluster.postgresql.parameters.wal_compression` parameter to `on`. Doing so will reduce the size of the WAL files and can help reduce replication lag in a congested network. Changing `wal_compression` does not require a restart of the CloudNativePG cluster.

--- a/charts/paradedb/docs/runbooks/CNPGScheduledBackupStalled.md
+++ b/charts/paradedb/docs/runbooks/CNPGScheduledBackupStalled.md
@@ -1,0 +1,51 @@
+# CNPGScheduledBackupStalled
+
+## Description
+
+The `CNPGScheduledBackupStalled` alert is triggered when a ScheduledBackup's `nextScheduleTime` is more than an hour in the past.
+
+The operator advances `nextScheduleTime` each time it triggers a backup. A time that has passed and not moved means the schedule is no longer being reconciled — the operator is not creating Backup objects for this cluster.
+
+This is a different failure from a backup that runs and errors. **Backups stop silently rather than failing**, so nothing produces a failed Backup object and `CNPGBackupFailed` never fires. Without this alert, the first signal would be `CNPGBackupStale` 26 hours later.
+
+## Impact
+
+No new backups are being attempted. The recovery window stops advancing from the moment the schedule stalled, and stays frozen until someone notices.
+
+## Diagnosis
+
+Check the ScheduledBackup's recorded times:
+
+```sh
+kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> <name> \
+  -o jsonpath='{.status.lastCheckTime}{"\n"}{.status.lastScheduleTime}{"\n"}{.status.nextScheduleTime}{"\n"}'
+```
+
+`lastCheckTime` is the useful one: it is when the operator last looked at this object. If it is also stale, the operator is not reconciling — the problem is the operator, not the schedule.
+
+Check the operator is running and look for errors mentioning this cluster:
+
+```sh
+kubectl get pods -n cnpg-system
+kubectl logs -n cnpg-system deploy/cnpg-controller-manager --since=2h | grep -i <cluster>
+```
+
+Also confirm the ScheduledBackup still points at a cluster that exists, and that it is not suspended:
+
+```sh
+kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> <name> -o yaml | grep -E 'suspend|cluster:'
+```
+
+## Mitigation
+
+If the operator is unhealthy, that is the incident — a stalled schedule is a symptom, and every cluster it manages is affected, not just this one.
+
+If the ScheduledBackup is suspended and should not be, unsuspend it.
+
+If the schedule itself is malformed, correct the cron expression. The operator will not advance `nextScheduleTime` past an expression it cannot parse.
+
+Once reconciliation resumes, take a backup by hand to close the gap that accumulated while the schedule was stalled:
+
+```sh
+kubectl cnpg backup <cluster> -n <namespace>
+```

--- a/charts/paradedb/docs/runbooks/CNPGScheduledBackupStalled.md
+++ b/charts/paradedb/docs/runbooks/CNPGScheduledBackupStalled.md
@@ -4,9 +4,9 @@
 
 The `CNPGScheduledBackupStalled` alert is triggered when a ScheduledBackup's `nextScheduleTime` is more than an hour in the past.
 
-The operator advances `nextScheduleTime` each time it triggers a backup. A time that has passed and not moved means the schedule is no longer being reconciled — the operator is not creating Backup objects for this cluster.
+The operator advances `nextScheduleTime` each time it triggers a backup. A time that has passed without moving means the schedule is no longer being reconciled, so the operator is not creating Backup objects for this cluster.
 
-This is a different failure from a backup that runs and errors. **Backups stop silently rather than failing**, so nothing produces a failed Backup object and `CNPGBackupFailed` never fires. Without this alert, the first signal would be `CNPGBackupStale` 26 hours later.
+This is a different failure from a backup that runs and errors. Backups stop silently rather than failing, so nothing produces a failed Backup object and `CNPGBackupFailed` never fires. Without this alert, the first signal would be `CNPGBackupStale` 26 hours later.
 
 ## Impact
 
@@ -14,31 +14,30 @@ No new backups are being attempted. The recovery window stops advancing from the
 
 ## Diagnosis
 
-Check the ScheduledBackup's recorded times:
+- Check the ScheduledBackup's recorded times:
 
-```sh
-kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> <name> \
-  -o jsonpath='{.status.lastCheckTime}{"\n"}{.status.lastScheduleTime}{"\n"}{.status.nextScheduleTime}{"\n"}'
+```bash
+kubectl get -n <namespace> scheduledbackup/<scheduledbackup-name> -o 'jsonpath={.status.lastCheckTime}{"\n"}{.status.lastScheduleTime}{"\n"}{.status.nextScheduleTime}{"\n"}'
 ```
 
-`lastCheckTime` is the useful one: it is when the operator last looked at this object. If it is also stale, the operator is not reconciling — the problem is the operator, not the schedule.
+`lastCheckTime` is the useful one, since it is when the operator last looked at this object. If it is also stale, the operator is not reconciling and the problem is the operator rather than the schedule.
 
-Check the operator is running and look for errors mentioning this cluster:
+- Check the operator is running, and look for errors mentioning this cluster:
 
-```sh
-kubectl get pods -n cnpg-system
-kubectl logs -n cnpg-system deploy/cnpg-controller-manager --since=2h | grep -i <cluster>
+```bash
+kubectl get -n cnpg-system pods -l "app.kubernetes.io/name=cloudnative-pg"
+kubectl logs -n cnpg-system -l "app.kubernetes.io/name=cloudnative-pg" --since=2h | grep -i paradedb
 ```
 
-Also confirm the ScheduledBackup still points at a cluster that exists, and that it is not suspended:
+- Confirm the ScheduledBackup still points at a cluster that exists, and that it is not suspended:
 
-```sh
-kubectl get scheduledbackups.postgresql.cnpg.io -n <namespace> <name> -o yaml | grep -E 'suspend|cluster:'
+```bash
+kubectl get -n <namespace> scheduledbackup/<scheduledbackup-name> -o yaml | grep -E 'suspend|cluster:'
 ```
 
 ## Mitigation
 
-If the operator is unhealthy, that is the incident — a stalled schedule is a symptom, and every cluster it manages is affected, not just this one.
+If the operator is unhealthy, that is the incident. A stalled schedule is a symptom, and every cluster the operator manages is affected, not just this one.
 
 If the ScheduledBackup is suspended and should not be, unsuspend it.
 
@@ -46,6 +45,6 @@ If the schedule itself is malformed, correct the cron expression. The operator w
 
 Once reconciliation resumes, take a backup by hand to close the gap that accumulated while the schedule was stalled:
 
-```sh
-kubectl cnpg backup <cluster> -n <namespace>
+```bash
+kubectl cnpg backup paradedb -n <namespace>
 ```

--- a/charts/paradedb/docs/runbooks/PostgreSQLLongRunningQueriesWarning.md
+++ b/charts/paradedb/docs/runbooks/PostgreSQLLongRunningQueriesWarning.md
@@ -1,0 +1,63 @@
+# PostgreSQLLongRunningQueriesWarning
+
+## Description
+
+The `PostgreSQLLongRunningQueriesWarning` alert is triggered when the primary instance of a CloudNativePG cluster has a query that has been running for more than two hours.
+
+The alert reads only the **primary**. Long-running reads on a standby are expected — that is often what standbys are for — and would otherwise page constantly on read-heavy replicas.
+
+## Impact
+
+A long-running query is not a problem in itself. An analytical query or an index build can legitimately run for hours. What makes it worth alerting on is what a long-running transaction holds open:
+
+- **It holds back `xmin`**, so autovacuum cannot clean up dead tuples newer than the transaction's snapshot. Bloat accumulates across the whole database, not just the tables the query touches.
+- **It may hold locks** that block DDL, and anything queueing behind that DDL, producing a stall far away from the query itself.
+- **On a standby, it can delay replay** where `hot_standby_feedback` is on, which surfaces as physical replication lag.
+
+The second-order effects usually arrive before anyone notices the query.
+
+## Diagnosis
+
+Find what is actually running, longest first:
+
+```sql
+SELECT pid,
+       now() - query_start AS duration,
+       state,
+       wait_event_type,
+       wait_event,
+       left(query, 200) AS query
+FROM pg_stat_activity
+WHERE state <> 'idle'
+  AND query_start < now() - interval '2 hours'
+ORDER BY query_start;
+```
+
+Two cases look identical on the dashboard and need opposite responses:
+
+- **`state = 'active'`** — the query is genuinely working. It may just be slow, or under-indexed.
+- **`state = 'idle in transaction'`** — nothing is executing, but the transaction is open and still holding its snapshot and locks. This is almost always an application that opened a transaction and did not commit, and it is the more damaging of the two.
+
+Check whether anything is blocked behind it:
+
+```sql
+SELECT pid, pg_blocking_pids(pid) AS blocked_by, left(query, 120)
+FROM pg_stat_activity
+WHERE cardinality(pg_blocking_pids(pid)) > 0;
+```
+
+## Mitigation
+
+For a genuinely slow query, the fix is the query — check its plan and whether it has the indexes it needs.
+
+For `idle in transaction`, the fix is the application: something is not committing or rolling back. Consider setting `idle_in_transaction_session_timeout` so the database bounds this itself rather than relying on an alert.
+
+To cancel a query without dropping the connection:
+
+```sql
+SELECT pg_cancel_backend(<pid>);
+```
+
+Use `pg_terminate_backend(<pid>)` only if cancelling does not work — it drops the connection, which the application must be able to handle.
+
+Before cancelling anything, check it is not a maintenance operation someone started deliberately. A cancelled `CREATE INDEX CONCURRENTLY` leaves an invalid index behind that has to be dropped by hand.

--- a/charts/paradedb/docs/runbooks/PostgreSQLLongRunningQueriesWarning.md
+++ b/charts/paradedb/docs/runbooks/PostgreSQLLongRunningQueriesWarning.md
@@ -4,23 +4,24 @@
 
 The `PostgreSQLLongRunningQueriesWarning` alert is triggered when the primary instance of a CloudNativePG cluster has a query that has been running for more than two hours.
 
-The alert reads only the **primary**. Long-running reads on a standby are expected — that is often what standbys are for — and would otherwise page constantly on read-heavy replicas.
+The alert reads only the primary. Long-running reads on a standby are expected, since that is often what standbys are for, and would otherwise page constantly on read-heavy replicas.
 
 ## Impact
 
 A long-running query is not a problem in itself. An analytical query or an index build can legitimately run for hours. What makes it worth alerting on is what a long-running transaction holds open:
 
-- **It holds back `xmin`**, so autovacuum cannot clean up dead tuples newer than the transaction's snapshot. Bloat accumulates across the whole database, not just the tables the query touches.
-- **It may hold locks** that block DDL, and anything queueing behind that DDL, producing a stall far away from the query itself.
-- **On a standby, it can delay replay** where `hot_standby_feedback` is on, which surfaces as physical replication lag.
+- It holds back `xmin`, so autovacuum cannot clean up dead tuples newer than the transaction's snapshot. Bloat accumulates across the whole database, not just the tables the query touches.
+- It may hold locks that block DDL, and anything queueing behind that DDL, producing a stall far away from the query itself.
+- On a standby, it can delay replay where `hot_standby_feedback` is on, which surfaces as physical replication lag.
 
 The second-order effects usually arrive before anyone notices the query.
 
 ## Diagnosis
 
-Find what is actually running, longest first:
+- Find what is running, longest first:
 
-```sql
+```bash
+kubectl exec -n <namespace> -it services/paradedb-rw -- psql -c "
 SELECT pid,
        now() - query_start AS duration,
        state,
@@ -31,33 +32,37 @@ FROM pg_stat_activity
 WHERE state <> 'idle'
   AND query_start < now() - interval '2 hours'
 ORDER BY query_start;
+"
 ```
 
 Two cases look identical on the dashboard and need opposite responses:
 
-- **`state = 'active'`** — the query is genuinely working. It may just be slow, or under-indexed.
-- **`state = 'idle in transaction'`** — nothing is executing, but the transaction is open and still holding its snapshot and locks. This is almost always an application that opened a transaction and did not commit, and it is the more damaging of the two.
+- `state = 'active'` means the query is genuinely working. It may just be slow, or under-indexed.
+- `state = 'idle in transaction'` means nothing is executing, but the transaction is open and still holding its snapshot and locks. This is almost always an application that opened a transaction and did not commit, and it is the more damaging of the two.
 
-Check whether anything is blocked behind it:
+- Check whether anything is blocked behind it:
 
-```sql
-SELECT pid, pg_blocking_pids(pid) AS blocked_by, left(query, 120)
+```bash
+kubectl exec -n <namespace> -it services/paradedb-rw -- psql -c "
+SELECT pid, pg_blocking_pids(pid) AS blocked_by, left(query, 120) AS query
 FROM pg_stat_activity
 WHERE cardinality(pg_blocking_pids(pid)) > 0;
+"
 ```
 
 ## Mitigation
 
-For a genuinely slow query, the fix is the query — check its plan and whether it has the indexes it needs.
+For a genuinely slow query, the fix is the query. Check its plan and whether it has the indexes it needs.
 
-For `idle in transaction`, the fix is the application: something is not committing or rolling back. Consider setting `idle_in_transaction_session_timeout` so the database bounds this itself rather than relying on an alert.
+For `idle in transaction`, the fix is the application, which is not committing or rolling back. Consider setting `cluster.postgresql.parameters.idle_in_transaction_session_timeout` so the database bounds this itself rather than relying on an alert.
 
 To cancel a query without dropping the connection:
 
-```sql
-SELECT pg_cancel_backend(<pid>);
+```bash
+kubectl exec -n <namespace> -it services/paradedb-rw -- psql -c "SELECT pg_cancel_backend(<pid>);"
 ```
 
-Use `pg_terminate_backend(<pid>)` only if cancelling does not work — it drops the connection, which the application must be able to handle.
+Use `pg_terminate_backend(<pid>)` only if cancelling does not work, since it drops the connection and the application must be able to handle that.
 
-Before cancelling anything, check it is not a maintenance operation someone started deliberately. A cancelled `CREATE INDEX CONCURRENTLY` leaves an invalid index behind that has to be dropped by hand.
+> [!IMPORTANT]
+> Before cancelling anything, check it is not a maintenance operation someone started deliberately. A cancelled `CREATE INDEX CONCURRENTLY` leaves an invalid index behind that has to be dropped by hand.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

Four runbooks for CNPG alert rules that already existed but had nothing to link to, written to match the standard established in #219.

**Base changed from `main` to `dev`**, and the branch rebased onto it. #219 merged to `dev`, so that is where the other twelve runbooks live; rebasing onto `main` would have put these four next to the pre-standardization copies. Change it back if `main` was intended.

## What

| File | Alert |
| --- | --- |
| `CNPGBackupFailed.md` | the most recent backup attempt failed |
| `CNPGBackupStale.md` | the most recent successful backup is over 26 hours old |
| `CNPGScheduledBackupStalled.md` | a ScheduledBackup's `nextScheduleTime` is over an hour in the past |
| `PostgreSQLLongRunningQueriesWarning.md` | a query on the primary has run for over two hours |

The rules live in paradedb/mcc, so there is no `runbook_url` wiring to change here.

## Why these three backup alerts are separate

They catch three different ways backups stop, and only one of them involves a failure.

`CNPGBackupFailed` needs something to report a failure. `CNPGScheduledBackupStalled` covers the case where the operator stops advancing the schedule, so no Backup object is ever created and nothing fails. `CNPGBackupStale` is the backstop that fires on the outcome regardless of cause, including backups that were switched off and forgotten.

Each runbook now links to the other two where its diagnosis says to distinguish between them, which the original text described in prose without linking.

## Alignment with #219

`CNPGBackupFailed.md` had the same unterminated-fence bug #219 was opened to fix: one ` ```sh ` opener against three bare fences. The first bare fence opened a block, so the "Common causes" paragraph and its bullet list rendered as code while the two `kubectl` commands above them rendered as prose. Fixed.

The rest, matching the twelve runbooks on `dev`:

- `kubectl <verb> -n <namespace> <type>/<name>` throughout, so `get backups` and `describe backup/<backup-name>` rather than the fully qualified `backups.postgresql.cnpg.io` forms
- the cluster is `paradedb`, not `<cluster>`; instances are `pod/<instance-pod-name>`, not `<cluster>-N`
- operator logs by label selector rather than `deploy/cnpg-controller-manager`, which is how the other runbooks reach the operator
- every fence is ` ```bash ` apart from SQL and one log sample
- bold reserved for severity labels, so the bold-led bullet lists are plain prose now
- no em dashes
- "Common causes, roughly in order of likelihood" claimed an ordering nothing here establishes, and is now just "Common causes" — the same phrasing removed from `CNPGClusterLogicalReplicationErrors` in #219

`PostgreSQLLongRunningQueriesWarning.md` gave bare SQL with no way to run it. Its queries are wrapped in `kubectl exec ... -- psql -c` like every other runbook, so they can be pasted straight into a terminal, and its warning about cancelling a `CREATE INDEX CONCURRENTLY` is a callout rather than a trailing sentence.

One stale reference fixed: `CNPGBackupFailed` pointed at `CNPGClusterLowDiskSpaceWarning`, whose runbook #219 merged into `CNPGClusterLowDiskSpace`.

## Tests

Run across all 16 runbooks, the 12 from #219 plus these 4:

- Every code fence balanced, with matching opener and closer counts per file.
- Every file has exactly the four house sections and nothing else.
- Every `kubectl` invocation matches `kubectl <verb> -n <namespace> …`.
- All placeholders kebab-case; no `<cluster>`, no `postgresql.cnpg.io` long forms, no em dashes, no ` ```sh `.
- Bold appears only as `**Warning level**` / `**Critical level**`.
- `markdownlint` v0.37.0 with the repo's `.markdownlint.yaml`, and `codespell --check-filenames`: both clean.