### PR TITLE
feat(paradedb): Add WAL replay progress instrumentation

### DIFF
--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -251,6 +251,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | cluster.monitoring.instrumentation.paradedbIndex | bool | `true` | Enable ParadeDB index metrics |
 | cluster.monitoring.instrumentation.pgStatActivity | bool | `true` | Enable pg_stat_activity long-running query metrics |
 | cluster.monitoring.instrumentation.pgStatStatements | bool | `true` | Enable planning and execution statistics for all SQL statements. Increases shared memory usage. |
+| cluster.monitoring.instrumentation.replication | bool | `true` | Enable WAL replay progress metrics. Runs against `postgres` rather than the application database, so it keeps reporting on a cluster whose application database is named something the metrics exporter cannot reach. |
 | cluster.monitoring.podMonitor.enabled | bool | `true` | Whether to enable the PodMonitor |
 | cluster.monitoring.podMonitor.labels | object | `{}` | Additional labels to set on the generated PodMonitor resource. Add labels your monitoring stack requires (for example `team-name`). |
 | cluster.monitoring.podMonitor.metricRelabelings | list | `[]` | The list of metric relabelings for the PodMonitor. Applied to samples before ingestion. |

--- a/charts/paradedb/templates/cluster.yaml
+++ b/charts/paradedb/templates/cluster.yaml
@@ -140,7 +140,7 @@ spec:
 
   monitoring:
     disableDefaultQueries: {{ .Values.cluster.monitoring.disableDefaultQueries }}
-    {{- if or .Values.cluster.monitoring.instrumentation.paradedbIndex .Values.cluster.monitoring.instrumentation.logicalReplication .Values.cluster.monitoring.instrumentation.pgStatStatements .Values.cluster.monitoring.instrumentation.pgStatActivity (not (empty .Values.cluster.monitoring.customQueries)) }}
+    {{- if or .Values.cluster.monitoring.instrumentation.paradedbIndex .Values.cluster.monitoring.instrumentation.logicalReplication .Values.cluster.monitoring.instrumentation.pgStatStatements .Values.cluster.monitoring.instrumentation.pgStatActivity .Values.cluster.monitoring.instrumentation.replication (not (empty .Values.cluster.monitoring.customQueries)) }}
     customQueriesConfigMap:
     {{- if .Values.cluster.monitoring.instrumentation.paradedbIndex }}
       - name: {{ include "cluster.fullname" . }}-monitoring-paradedb-index
@@ -156,6 +156,10 @@ spec:
     {{- end }}
     {{- if .Values.cluster.monitoring.instrumentation.pgStatActivity }}
       - name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-activity
+        key: custom-queries
+    {{- end }}
+    {{- if .Values.cluster.monitoring.instrumentation.replication }}
+      - name: {{ include "cluster.fullname" . }}-monitoring-replication
         key: custom-queries
     {{- end }}
     {{- if not (empty .Values.cluster.monitoring.customQueries) }}

--- a/charts/paradedb/templates/monitoring-replication.yaml
+++ b/charts/paradedb/templates/monitoring-replication.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.cluster.monitoring.instrumentation.replication }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cluster.fullname" . }}-monitoring-replication
+  namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/reload: ""
+    {{- include "cluster.labels" . | nindent 4 }}
+data:
+  custom-queries: |
+    paradedb_replication:
+      query: |
+        SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END AS in_recovery
+             , CASE WHEN pg_last_wal_receive_lsn() IS NOT NULL THEN 1 ELSE 0 END AS wal_received
+             , COALESCE(EXTRACT(epoch FROM (now() - pg_last_xact_replay_timestamp())), 0) AS replay_age_seconds
+             , COALESCE(pg_wal_lsn_diff(pg_last_wal_replay_lsn(), '0/0'), 0) AS replay_lsn_bytes;
+      target_databases: ["postgres"]
+      metrics:
+        - in_recovery:
+            description: 1 when this instance is a standby replaying WAL, 0 when it is the primary
+            usage: GAUGE
+        - wal_received:
+            description: 1 when this instance has received WAL over streaming replication since start, 0 when it replays only from the WAL archive
+            usage: GAUGE
+        - replay_age_seconds:
+            description: Seconds since the last transaction this instance replayed committed on the primary; 0 on a primary
+            usage: GAUGE
+        - replay_lsn_bytes:
+            description: WAL position replayed by this instance, in bytes; flat while replay is stalled and 0 on a primary
+            usage: GAUGE
+{{- end }}

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -24,6 +24,8 @@ spec:
           key: custom-queries
         - name: monitoring-paradedb-monitoring-pg-stat-activity
           key: custom-queries
+        - name: monitoring-paradedb-monitoring-replication
+          key: custom-queries
         - name: monitoring-paradedb-monitoring-user-metrics
           key: custom-queries
       enablePodMonitor: false
@@ -154,6 +156,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: monitoring-paradedb-monitoring-pg-stat-activity
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitoring-paradedb-monitoring-replication
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/paradedb/test/monitoring/01-monitoring_cluster.yaml
@@ -22,6 +22,7 @@ cluster:
       logicalReplication: true
       pgStatStatements: true
       pgStatActivity: true
+      replication: true
     tls:
       enabled: true
     customQueries:

--- a/charts/paradedb/values.schema.json
+++ b/charts/paradedb/values.schema.json
@@ -262,6 +262,9 @@
                                 },
                                 "pgStatStatements": {
                                     "type": "boolean"
+                                },
+                                "replication": {
+                                    "type": "boolean"
                                 }
                             }
                         },

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -317,6 +317,10 @@ cluster:
       pgStatStatements: true
       # -- Enable pg_stat_activity long-running query metrics
       pgStatActivity: true
+      # -- Enable WAL replay progress metrics. Runs against `postgres` rather than the application
+      # database, so it keeps reporting on a cluster whose application database is named something
+      # the metrics exporter cannot reach.
+      replication: true
     podMonitor:
       # -- Whether to enable the PodMonitor
       enabled: true


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

A fifth `cluster.monitoring.instrumentation` toggle, `replication`, defaulting on alongside `paradedbIndex`, `logicalReplication`, `pgStatStatements` and `pgStatActivity`. It renders a `<fullname>-monitoring-replication` ConfigMap exporting four series about WAL replay.

## Why

CNPG's built-in `pg_replication` collector already reports standby lag, but it runs against the **application database**. On a cluster whose bootstrap left that database misnamed, every default collector fails to connect:

```
FATAL:  database "app" does not exist
"Error collecting user query","query":"pg_settings","targetDatabase":"app"
```

and the lag metric is simply absent. A standby can then stop replaying entirely with nothing downstream holding a series to alert on — the cluster keeps serving reads, just against steadily older data, and the only visible symptom is metrics that never arrive.

Since the whole point of this metric is to make that failure visible, it must not share the dependency that hides it. This query targets `postgres`, which every cluster has, so replay progress reports regardless of how the application database is named.

## How

`templates/monitoring-replication.yaml`, guarded by the new toggle, plus the corresponding entry in `cluster.yaml`'s `customQueriesConfigMap` list and its `or` guard. Four columns, chosen so an alert can tell "behind" from "stopped":

| column | why it is there |
| --- | --- |
| `in_recovery` | separates standbys from primaries in the alert expression |
| `replay_age_seconds` | the headline number, but it drifts upward on an idle primary with no new transactions to replay, so it is **not** proof of a stall on its own |
| `replay_lsn_bytes` | monotonic while replay progresses; a flat value alongside a rising age is a genuine stall, with no idle-primary false positive |
| `wal_received` | distinguishes a streaming standby from one replaying only out of the WAL archive — the latter's stalls become unrecoverable once the segments it needs age out |

`wal_received` is described as "has received WAL over streaming since start" rather than "is currently streaming", because `pg_last_wal_receive_lsn()` retains its last value after a walreceiver dies; it is NULL only when nothing has ever streamed. The description says what the function actually reports.

## Tests

- `test/monitoring` updated: `replication: true` added to the explicit instrumentation list, plus the ConfigMap entry and resource assertion. The assert compares `customQueriesConfigMap` as an ordered list, so the new entry is placed where the template emits it — after `pg-stat-activity`, before `user-metrics`.
- `values.schema.json` and the helm-docs README table updated for the new value.
- The SQL was executed against a real PostgreSQL 16 primary and a `pg_basebackup` streaming standby rather than only eyeballed:

  | | `in_recovery` | `wal_received` | `replay_age_seconds` | `replay_lsn_bytes` |
  | --- | --- | --- | --- | --- |
  | primary | 0 | 0 | 0 | 0 |
  | streaming standby | 1 | 1 | 0.00 | 50331648 |

- The embedded `custom-queries` document was parsed and its `metrics:` block asserted to name exactly the columns the `SELECT` produces.
- Not run: `helm template` / `helm lint`. `get.helm.sh` is blocked by my environment's network policy, so I could not install Helm. The template is structurally identical to its four siblings, but CI rendering it is the real check.
- The archive-only case (`wal_received = 0` on a standby) was not reproduced locally; it is confirmed by a real archive-only replica, where `pg_last_wal_receive_lsn()` returns NULL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ2vMFbsdNyKhK8cozpkEm)_