### PR TITLE
alerts: name the runbook file literally in every rule

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-instance_metrics_absent.yaml
@@ -7,7 +7,7 @@ annotations:
     ParadeDB CNPG instance "{{ .namespace }}/{{ .labels.pod }}" has had an unreachable metrics endpoint for 10 minutes, so its metrics exporter is hung.
 
     The lag, HA and replication alerts all read from this exporter and will not fire while it is down. A hung exporter has previously coincided with a frozen standby, so physical replication may be stuck and unmonitored. Check the instance directly.
-  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGInstanceMetricsAbsent.md
 expr: |
   up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 0
 for: 10m

--- a/charts/paradedb/prometheus_rules/cluster-instances_on_same_node.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-instances_on_same_node.yaml
@@ -7,7 +7,7 @@ annotations:
     ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has {{ .value }} instances on the same node {{ .labels.node }}.
 
     A failure or scheduled downtime of a single node will lead to a potential service disruption and/or data loss.
-  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterInstancesOnSameNode.md
 expr: |
   count by (node) (kube_pod_info{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 1
 for: 5m

--- a/charts/paradedb/prometheus_rules/cluster-offline.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-offline.yaml
@@ -7,7 +7,7 @@ annotations:
     ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has no ready instances.
 
     Having an offline cluster means your applications will not be able to access the database, leading to potential service disruption and/or data loss.
-  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterOffline.md
 expr: |
   (count(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR on() vector(0)) == 0
 for: 5m

--- a/charts/paradedb/prometheus_rules/cluster-zone_spread-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-zone_spread-warning.yaml
@@ -7,7 +7,7 @@ annotations:
     ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has instances in the same availability zone.
 
     A disaster in one availability zone will lead to a potential service disruption and/or data loss.
-  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/{{ $alert }}.md
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterZoneSpreadWarning.md
 expr: |
   {{ .Values.cluster.instances }} > count(count by (label_topology_kubernetes_io_zone) (kube_pod_info{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) < 3
 for: 5m


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Four `runbook_url` values in `prometheus_rules/`, changed from `{{ $alert }}.md` to the literal filename. 4 files, +4 −4, nothing else.

## Why

I went looking for rules whose `runbook_url` sat in a different place from the rest, and there aren't any — every rule in this repo is `alert` / `annotations` / `expr` / `for` / `labels`, with `summary` / `description` / `runbook_url` inside `annotations`, and `runbook_url` always the last annotation. Same in paradedb/mcc's 24 rules. The `description: |-` and `expr: |` block styles are uniform too.

What is not uniform is how the value is written. Fourteen rules name their runbook outright; four still used the template:

| Alert | Was | Now |
| --- | --- | --- |
| `CNPGClusterOffline` | `{{ $alert }}.md` | `CNPGClusterOffline.md` |
| `CNPGClusterZoneSpreadWarning` | `{{ $alert }}.md` | `CNPGClusterZoneSpreadWarning.md` |
| `CNPGClusterInstancesOnSameNode` | `{{ $alert }}.md` | `CNPGClusterInstancesOnSameNode.md` |
| `CNPGInstanceMetricsAbsent` | `{{ $alert }}.md` | `CNPGInstanceMetricsAbsent.md` |

The template only works while an alert and its runbook share a name. That stopped being true in #219, when each warning/critical pair was merged into one runbook covering both severities — which is exactly why the split existed: the ten rules that could no longer use it were converted, and these four were left because they still happened to work.

The stronger reason to drop it is that it fails quietly. Renaming a runbook leaves the template resolving to a file that no longer exists, and nothing in the diff shows it. That is not hypothetical: #219 renamed six runbooks, and paradedb/mcc#219 had to be opened afterwards to repair six `runbook_url`s in the other repo that had silently gone stale. Spelling the target out means a runbook rename cannot land without touching the rule that points at it.

## How

`sed` on the four values. No alert name, expression, threshold, `for` duration or label is touched, so nothing changes about what fires or how it routes.

## Tests

- All 18 alerts still resolve to a runbook that exists — each path checked against `docs/runbooks/` rather than by eye.
- No `{{ $alert }}.md` remains in `prometheus_rules/`.
- Ordering re-verified as uniform across all 18 files after the change.
- `templates/prometheus-rule.yaml` globs the directory rather than listing files, so nothing else needs updating.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_