### PR TITLE
alerts: give chart users backup, archiving and long-query alerting

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-backup_stale.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-backup_stale.yaml
@@ -1,0 +1,20 @@
+{{- $alert := "CNPGBackupStale" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: ParadeDB CNPG Cluster has no recent successful backup
+  description: |-
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" last completed a successful backup {{ .value }} seconds ago.
+
+    Backups are expected nightly, so 26 hours is one missed run plus two hours of grace. Everything written since that backup is outside the recovery window.
+
+    This fires on the outcome regardless of cause, so it covers backups that are failing, a schedule that has stopped being reconciled, and backups that were switched off and forgotten.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGBackupStale.md
+expr: |
+  time() - max(cnpg_collector_last_available_backup_timestamp{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 26 * 3600
+for: 15m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/prometheus_rules/cluster-continuous_archiving_failed.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-continuous_archiving_failed.yaml
@@ -1,0 +1,22 @@
+{{- $alert := "CNPGContinuousArchivingFailed" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: ParadeDB CNPG Cluster is failing to archive WAL
+  description: |-
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has failed its most recent WAL archival attempt more recently than its last successful one.
+
+    Point-in-time recovery is frozen at the last archived segment. Everything written since then exists only on the instance's own volume, and the data volume keeps growing because PostgreSQL retains WAL it has not archived.
+
+    This is separate from the backup alerts, which look at base backups. The cluster can report Ready=True with a recent successful backup throughout.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGContinuousArchivingFailed.md
+expr: |
+  cnpg_pg_stat_archiver_last_failed_time{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+  >
+  cnpg_pg_stat_archiver_last_archived_time{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+for: 15m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/prometheus_rules/cluster-long_running_queries-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-long_running_queries-warning.yaml
@@ -1,0 +1,28 @@
+{{- $alert := "PostgreSQLLongRunningQueriesWarning" -}}
+{{- if and (not (has $alert .excludeRules)) .Values.cluster.monitoring.instrumentation.pgStatActivity -}}
+alert: {{ $alert }}
+annotations:
+  summary: ParadeDB CNPG Cluster has a long running query on its primary
+  description: |-
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has a query on its primary instance that has been running for {{ .value }} seconds, more than the two hour threshold.
+
+    A long query is not a problem in itself, but a long transaction holds back xmin, so autovacuum cannot clean up dead tuples anywhere in the database, and it may hold locks that block DDL and anything queueing behind it.
+
+    Only the primary is read. Long running reads on a standby are expected.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/PostgreSQLLongRunningQueriesWarning.md
+expr: |
+  (
+    max by (namespace, pod) (
+      cnpg_pg_stat_activity_long_running_max_duration{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+    )
+    unless on (namespace, pod)
+    (
+      cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 1
+    )
+  ) > 7200
+for: 1m
+labels:
+  severity: warning
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes part of paradedb/mcc#183

## What

Three new rules in `prometheus_rules/`. The chart goes from 18 alerts to 21.

| Alert | Metric | New dependency |
| --- | --- | --- |
| `CNPGContinuousArchivingFailed` | `cnpg_pg_stat_archiver_last_failed_time` vs `_last_archived_time` | none |
| `CNPGBackupStale` | `cnpg_collector_last_available_backup_timestamp` | none |
| `PostgreSQLLongRunningQueriesWarning` | `cnpg_pg_stat_activity_long_running_max_duration` | none |

Names, thresholds and runbooks match the MCC rules for the same conditions — 26 hours for a stale backup, two hours for a long query — so the two surfaces agree rather than adding new divergence.

## Why

Anyone running this chart with their own Prometheus had **no backup alerting of any kind**: not a missed nightly, not a stalled scheduler, not dead WAL archiving. The MCC has had all of it for months.

The archiving condition is the one worth having first. It hides behind a healthy cluster status — `Ready=True`, a recent successful backup — while the recovery point silently stops advancing. That is the condition that ran for fifteen hours on our own infrastructure *with* an alert stack watching, and it would be indefinitely invisible to a self-hosted user.

## How

Two details worth review.

**Primary-only filtering.** The MCC restricts the long-query alert to the primary by joining `kube_customresource_primary_info`. That series does not exist for chart users, so this uses `unless on (namespace, pod) (cnpg_pg_replication_in_recovery == 1)` instead. That is CNPG-native, and the chart's own dashboard already uses the same metric for exactly this purpose — `(1 - cnpg_pg_replication_in_recovery)` as a primary-only multiplier on the archiver panels.

**Gating.** `PostgreSQLLongRunningQueriesWarning` is gated on `cluster.monitoring.instrumentation.pgStatActivity`, since that value is what produces its metric. The other two need no gate. No new values key, so no `helm-docs` regeneration.

## What is deliberately not here

`CNPGBackupFailed` and `CNPGScheduledBackupStalled`, the other two rules mcc#183 lists.

Both read `kube_customresource_*` series. #183 frames this as "document the kube-state-metrics prerequisite and ship them behind it", but the problem is worse than a prerequisite: those metric **names and labels are defined by the MCC's own `CustomResourceStateMetrics` configuration** in `infrastructure/metrics-clusters_postgresql_cnpg_io.yaml`, not by anything the chart installs. A user who enables kube-state-metrics without that exact config gets no such series, or differently-shaped ones. Shipping the rules alone would point people at metrics that never appear.

Closing that properly means the chart shipping the `CustomResourceStateMetrics` config as well. That is a larger change and deserves its own PR.

`CNPGBackupStale` limits the damage in the meantime. It fires on the *outcome* regardless of cause, so a self-hosted user still finds out within 26 hours whether backups were failing, the schedule stalled, or backups were switched off and forgotten — the three cases its runbook already tells you to distinguish between.

## Tests

- All 21 rules render to valid YAML with the same key order (`alert` / `annotations` / `expr` / `for` / `labels`) and `runbook_url` last in `annotations`, checked by substituting the exact context `templates/prometheus-rule.yaml` builds and parsing the result.
- All three new alerts point at runbooks that already exist in `docs/runbooks/` — added by #218 and #219.
- `codespell` clean.
- `templates/prometheus-rule.yaml` globs the directory, so the new files are picked up with no template change.

The chainsaw `monitoring` job is the real render check; `helm` could not be installed in this environment (the proxy 403s `get.helm.sh`), so local verification was the substitution above rather than `helm template`.

Note this does not conflict with #222, which touches four different files in the same directory.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_