### PR TITLE
alerts: scope every rule to its own cluster, and stop HA firing on replicas

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-ha-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-ha-critical.yaml
@@ -13,7 +13,15 @@ annotations:
     This alarm will be constantly triggered if your cluster is configured to run with only 1 instance. If this is intentional, you may want to silence it.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHA.md
 expr: |
-  max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}"}) < 1
+  max by (job) (
+    (
+      cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+      -
+      cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+    )
+    unless on (namespace, pod)
+    (cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 1)
+  ) < 1
 for: 5m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-ha-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-ha-warning.yaml
@@ -11,7 +11,15 @@ annotations:
     This alarm will be constantly triggered if your cluster is configured to run with less than 3 instances. If this is intentional, you may want to silence it.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHA.md
 expr: |
-  max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}"}) < 2
+  max by (job) (
+    (
+      cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+      -
+      cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+    )
+    unless on (namespace, pod)
+    (cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 1)
+  ) < 2
 for: 5m
 labels:
   severity: warning

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_errors-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_errors-critical.yaml
@@ -9,7 +9,7 @@ annotations:
     CRITICAL: High error rate indicates persistent replication issues requiring immediate attention. This could lead to significant data inconsistency or complete replication failure. Errors include both apply errors and sync errors. The subscription may stop working if errors continue.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterLogicalReplicationErrors.md
 expr: |
-  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count[5m])), "cluster", "$1", "job", ".+/(.+)") >= 5
+  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[5m])), "cluster", "$1", "job", ".+/(.+)") >= 5
 for: 0m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_errors.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_errors.yaml
@@ -9,7 +9,7 @@ annotations:
     This includes both apply errors (during normal replication) and sync errors (during initial table sync). Errors indicate data consistency issues that need immediate attention to prevent data divergence.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterLogicalReplicationErrors.md
 expr: |
-  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count[5m])), "cluster", "$1", "job", ".+/(.+)") > 0
+  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}[5m])), "cluster", "$1", "job", ".+/(.+)") > 0
 for: 1m
 labels:
   severity: warning

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_lagging-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_lagging-critical.yaml
@@ -16,13 +16,13 @@ annotations:
 expr: |
   (
     # Receipt lag - not receiving WAL data
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_receipt_lag_seconds), "cluster", "$1", "job", ".+/(.+)") > 300
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_receipt_lag_seconds{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") > 300
   ) or (
     # Apply lag - not applying received data
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_lag_seconds), "cluster", "$1", "job", ".+/(.+)") > 300
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_lag_seconds{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") > 300
   ) or (
     # LSN distance - large amount of pending data
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 4
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 4
   )
 for: 2m
 labels:

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_lagging.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_lagging.yaml
@@ -16,13 +16,13 @@ annotations:
 expr: |
   (
     # Receipt lag - time since last message received
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_receipt_lag_seconds), "cluster", "$1", "job", ".+/(.+)") > 60
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_receipt_lag_seconds{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") > 60
   ) or (
     # Apply lag - time delay in applying changes
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_lag_seconds), "cluster", "$1", "job", ".+/(.+)") > 60
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_lag_seconds{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") > 60
   ) or (
     # LSN distance - bytes pending to be applied
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 1
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 1
   )
 for: 5m
 labels:

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
@@ -14,12 +14,12 @@ annotations:
 expr: |
   (
     # Subscription is explicitly disabled
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 0
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") == 0
   ) or (
     # Subscription is enabled but stuck (no worker process with significant lag)
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 1
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") <= 0
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") == 1
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") <= 0
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
   )
 for: 15m
 labels:

--- a/charts/paradedb/prometheus_rules/cluster-logical_replication_stopped.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-logical_replication_stopped.yaml
@@ -13,12 +13,12 @@ annotations:
 expr: |
   (
     # Subscription is explicitly disabled
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 0
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") == 0
   ) or (
     # Subscription is enabled but stuck (no worker process with significant lag)
-    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 1
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") <= 0
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
+    label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") == 1
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") <= 0
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
   )
 for: 5m
 labels:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

Relates to paradedb/mcc#184. Three correctness bugs found by diffing the chart's rules against the MCC's rules for the same conditions. 8 files, +34 −18. No threshold, severity, `for` duration or alert name changes.

## 1. Six logical replication rules matched every namespace

The subscription rules aggregated the raw series with no selector at all:

```
max by (namespace, job, subname) (cnpg_pg_stat_subscription_receipt_lag_seconds)
```

Prometheus evaluates that across everything it scrapes. A chart installed in one namespace alerted on subscriptions belonging to **any other cluster in range** — and stamped them with this cluster's identity, because `namespace` and `cnpg_cluster` in the `labels` block are fixed at render time. On-call would get a page naming cluster A for a subscription problem in cluster B.

These were the only six rules in the directory with no namespace filter. All seven subscription metrics across them now select on `namespace` and `podSelector`, matching every other rule.

## 2. The HA rules matched other clusters in the same namespace

`CNPGClusterHACritical` and `CNPGClusterHAWarning` filtered on namespace but not on instance — the only two rules doing so. A second CNPG cluster in the same namespace fed the same expression. `max by (job)` kept the series apart, but the alert that fired still carried this cluster's name. They now select on `podSelector` too.

## 3. The HA rules fired continuously on a dedicated replica

This is the one worth reading. A dedicated replica is its own CNPG Cluster whose designated primary streams from the source cluster, so `streaming_replicas - is_wal_receiver_up` is **negative on a healthy one** and both HA rules fired forever.

The MCC hit exactly this and fixed it — `cnpg-vmrules/cluster-ha-critical.yaml` carries a four-line comment explaining it. The chart never got the fix, so **any chart user running a dedicated replica has `CNPGClusterHACritical` permanently on**. Given mcc#179 is open about supporting dedicated replicas, this is a shape that exists in the wild.

Both rules now carry the same exclusion:

```
unless on (namespace, pod) (cnpg_pg_replication_in_recovery == 1)
```

On a normal cluster this changes nothing. It only drops the standbys' own negative values, which the `max` never selected anyway — the MCC comment makes the same point. On a dedicated replica every instance is in recovery, the series empties, and the rule correctly stops matching.

One deviation from the MCC: it also tests `cnpg_paradedb_physical_replication_in_recovery` in that exclusion. No chart template produces that series, so this uses the CNPG-native metric alone.

## What I deliberately did not change

- **`CNPGClusterOffline` reads a different signal on each side** — `count(cnpg_collector_up) == 0` here versus `kube_customresource_instances_ready == 0` in the MCC. The MCC's version needs kube-state-metrics, which the chart is not taking on as a dependency, so the chart's version stays.
- **`CNPGInstanceMetricsAbsent` differs in both expression and `for`** (10m here, 5m in the MCC). The chart's simpler `up == 0` is defensible and its runbook documents the 10-minute delay as deliberate, to ride out restarts.
- **Physical and logical replication thresholds still diverge** — 1s/15s here against 5s/600s in the MCC. That needs a decision about which is right, and is the substance of mcc#184.

## Tests

- Every rule in the directory now selects on both `namespace` and `podSelector`; verified by audit, which is what surfaced bugs 1 and 2.
- All 21 rules render to valid YAML with consistent key ordering, checked by substituting the exact context `templates/prometheus-rule.yaml` builds.
- `codespell` clean.

`helm` could not be installed here (the proxy 403s `get.helm.sh`), so the chainsaw `monitoring` job is the first real render.

Does not conflict with #223, which adds three different files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_