### PR TITLE
ci: check that rules and runbooks point at each other

### DIFF
--- a/.github/scripts/check_runbook_links.py
+++ b/.github/scripts/check_runbook_links.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check that alert rules and runbooks agree with each other.
+
+Two failure modes have bitten this repository, both silently:
+
+  * a rule points at a runbook that does not exist, because the runbook was
+    renamed or merged into another one and the rule was not updated;
+  * a runbook exists that no rule points at, so nobody is ever sent to it.
+
+Runbooks listed in EXTERNALLY_REFERENCED are documented here rather than
+referenced by a rule in this repository. Keep that list short and explain
+each entry.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RULES = ROOT / "charts/paradedb/prometheus_rules"
+RUNBOOKS = ROOT / "charts/paradedb/docs/runbooks"
+
+# Runbook -> why no rule in this repository points at it.
+EXTERNALLY_REFERENCED = {
+    "CNPGBackupFailed.md": (
+        "alert lives in paradedb/mcc; needs kube_customresource_* series that "
+        "the chart does not install"
+    ),
+    "CNPGScheduledBackupStalled.md": (
+        "alert lives in paradedb/mcc; needs kube_customresource_* series that "
+        "the chart does not install"
+    ),
+}
+
+RUNBOOK_URL = re.compile(r"runbooks/(?P<name>(?:\{\{[^}]*\}\}|[^\s\"'])+\.md)")
+ALERT_NAME = re.compile(r"\$alert\s*:=\s*\"(?P<name>[^\"]+)\"")
+
+
+def main() -> int:
+    errors: list[str] = []
+    referenced: set[str] = set()
+
+    rule_files = sorted(RULES.glob("*.yaml"))
+    if not rule_files:
+        print(f"no rule files found under {RULES}", file=sys.stderr)
+        return 1
+
+    for path in rule_files:
+        text = path.read_text()
+        rel = path.relative_to(ROOT)
+
+        alert = ALERT_NAME.search(text)
+        alert_name = alert.group("name") if alert else path.stem
+
+        urls = RUNBOOK_URL.findall(text)
+        if not urls:
+            errors.append(f"{rel}: {alert_name} has no runbook_url")
+            continue
+
+        for name in urls:
+            if "{{" in name:
+                errors.append(
+                    f"{rel}: {alert_name} builds its runbook_url from a template "
+                    f"({name}); name the file so a rename cannot pass silently"
+                )
+                continue
+            referenced.add(name)
+            if not (RUNBOOKS / name).is_file():
+                errors.append(f"{rel}: {alert_name} points at {name}, which does not exist")
+
+    for path in sorted(RUNBOOKS.glob("*.md")):
+        if path.name in referenced or path.name in EXTERNALLY_REFERENCED:
+            continue
+        errors.append(
+            f"{path.relative_to(ROOT)}: no alert rule points at this runbook. "
+            f"Wire it up, delete it, or add it to EXTERNALLY_REFERENCED in {pathlib.Path(__file__).name}"
+        )
+
+    for name, reason in sorted(EXTERNALLY_REFERENCED.items()):
+        if not (RUNBOOKS / name).is_file():
+            errors.append(
+                f"EXTERNALLY_REFERENCED lists {name} ({reason}), but no such runbook exists"
+            )
+
+    if errors:
+        print("Runbook link check failed:\n", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"ok: {len(rule_files)} rules, {len(referenced)} runbooks referenced, "
+        f"{len(EXTERNALLY_REFERENCED)} referenced only from paradedb/mcc"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-runbook-links.yml
+++ b/.github/workflows/check-runbook-links.yml
@@ -1,0 +1,34 @@
+# workflows/check-runbook-links.yml
+#
+# Check Runbook Links
+# Check that every alert rule points at a runbook that exists, and that every
+# runbook is pointed at by an alert rule.
+
+name: Check Runbook Links
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "charts/paradedb/prometheus_rules/**"
+      - "charts/paradedb/docs/runbooks/**"
+      - ".github/scripts/check_runbook_links.py"
+      - ".github/workflows/check-runbook-links.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: check-runbook-links-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-runbook-links:
+    name: Check Runbook Links
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Check Runbook Links
+        run: python3 .github/scripts/check_runbook_links.py


### PR DESCRIPTION
# Ticket(s) Closed

- Addresses item 4 of paradedb/mcc#184

That issue lists four items and says this one is "worth doing first and independently of the naming decision." It needs no decision from anyone, so here it is ahead of the naming and threshold questions.

## What

A script and a workflow. 2 files, no changes to any rule or runbook.

```
ok: 21 rules, 14 runbooks referenced, 2 referenced only from paradedb/mcc
```

## Why

Two failure modes have hit this repository, and **both were silent**.

**A rule pointing at a runbook that does not exist.** #219 merged six runbooks into three. That left six `runbook_url`s in paradedb/mcc resolving to deleted files. Nothing failed, nothing was flagged — they were found by hand afterwards and repaired in paradedb/mcc#219. They would have kept "working" right up until someone was paged at 3am and clicked the link.

**A runbook nothing points at.** `CNPGClusterHighPhysicalReplicationLagWarning.md` sat unreferenced by either repository until #219 deleted it — 3.9 KB of guidance nobody could ever be sent to. #184 flags it as its own item.

The check also catches a third, which is what made the first one invisible: a `runbook_url` built from `{{ $alert }}` rather than naming the file. That form only works while an alert and its runbook share a name, so a runbook rename leaves it resolving to nothing with no diff to show for it. #222 removed the last four; this stops them coming back.

## How

`EXTERNALLY_REFERENCED` lists the two runbooks documented here but referenced only from paradedb/mcc — `CNPGBackupFailed` and `CNPGScheduledBackupStalled`, whose alerts need `kube_customresource_*` series the chart does not install. Each carries its reason. That lets the "nothing points at this" rule stay strict instead of being weakened to accommodate them, and if either is ever wired up or deleted the list goes stale loudly rather than quietly.

The workflow matches `check-typo.yml`: same trigger set, same concurrency group shape, same `draft == false` gate. It is path-filtered to the rules, the runbooks, and the check itself.

## Tests

Verified by mutating the tree and confirming both the message and the exit code, rather than assuming:

| Case | Result |
| --- | --- |
| Rule points at a nonexistent runbook | fails, names the rule and the missing file |
| `{{ $alert }}.md` reintroduced | fails, explains why to name the file |
| Runbook with no rule pointing at it | fails, offers the three ways to resolve it |
| Clean tree | passes |

Worth noting: the second case initially reported "has no runbook_url", which was wrong. The pattern could not match a templated URL because of the space inside `{{ $alert }}`, so that branch had been unreachable. Fixed, and it is why that case is in the table rather than assumed to work.

Workflow YAML parses; `codespell` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_