### PR TITLE
ci: let the chainsaw suite be run on demand

### DIFF
--- a/.github/workflows/paradedb-test-chainsaw.yaml
+++ b/.github/workflows/paradedb-test-chainsaw.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - "gh-pages"
-  # Lets the suite be run against a branch on demand. Without this it only ever
-  # runs as a side effect of a pull request, so a merge to `dev` re-tests nothing
-  # and a run lost to a flaky download cannot be retried except by pushing.
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/paradedb-test-chainsaw.yaml
+++ b/.github/workflows/paradedb-test-chainsaw.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches-ignore:
       - "gh-pages"
+  # Lets the suite be run against a branch on demand. Without this it only ever
+  # runs as a side effect of a pull request, so a merge to `dev` re-tests nothing
+  # and a run lost to a flaky download cannot be retried except by pushing.
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds `workflow_dispatch` to `paradedb-test-chainsaw.yaml`. One trigger, four lines including the comment. Nothing else changes and pull requests trigger it exactly as before.

## Why

The suite only ever ran as a side effect of a pull request. Two consequences, both of which bit today.

**A merge re-tests nothing.** `monitoring` is the only test that sets `monitoring.enabled: true`, so it is the only one that renders `prometheus_rules/` at all — the other eleven install the chart with monitoring off and would pass whatever those expressions said. It never got past a setup-step download on #223, #224 or #225. So the three rules added by #223 and the eight changed by #224 reached `dev` **without their PromQL or Go templating ever being rendered**, and merging did not re-check them. The last run against `dev` itself was in March.

**A run lost to a flaky download cannot be retried on its own.** Re-running failed jobs works while a PR is open. Once it merges, the only way to exercise the chart again is to open another PR — which is why closing #225 removed the last pending validation of those eleven rules.

Tonight was an unusually bad case: a GitHub releases outage killed setup steps across six distinct artifacts (cosign, chainsaw, kind, `prometheus-operator-crds`, the CNPG chart) for roughly two hours. But the gap it exposed is structural, not weather.

## How

`workflow_dispatch` takes no inputs. The run targets whichever branch is selected in the Actions UI or passed to `gh workflow run --ref`, which is all this needs — the matrix is already derived from `ls charts/paradedb/test`.

## Tests

Workflow parses; triggers resolve to `pull_request` and `workflow_dispatch`, jobs to `test-list` and `test`.

The trigger only takes effect once this is on `dev`, since `workflow_dispatch` is read from the default branch. After merge it will be possible to run the suite against `dev` directly and finally render those eleven rules.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_