### PR TITLE
feat: alert when the metrics collector is answering but its queries fail

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsFailing.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsFailing.md
@@ -1,0 +1,91 @@
+# CNPGInstanceMetricsFailing
+
+## Description
+
+The `CNPGInstanceMetricsFailing` alert is triggered when a CloudNativePG instance's metrics collector reports that its most recent collection ended in an error for 15 minutes. The delay is long enough to ride out a single failed collection cycle, a restart or a failover, so when the alert fires the failure is persistent rather than transient.
+
+This is the counterpart to `CNPGInstanceMetricsAbsent`. That alert covers an exporter that has stopped responding, which is visible from outside. This one covers an exporter that responds normally while the queries behind individual metrics fail, which is not.
+
+## Impact
+
+The instance keeps serving queries. The risk is in the series that stop being published, because the alerts that read them are all `expr > threshold` rules: with no samples to evaluate they produce nothing rather than firing. They fail open, silently.
+
+Which alerts go blind depends on which queries are failing. If the collector cannot reach the application database, every default per-database query fails at once and that includes:
+
+- `CNPGClusterPhysicalReplicationLag*`, which reads `cnpg_pg_replication_lag`
+- `CNPGClusterHA*`, which reads `cnpg_pg_replication_streaming_replicas` and `cnpg_pg_replication_is_wal_receiver_up`
+- The logical replication alerts, which read `cnpg_pg_stat_subscription_*`
+
+A standby in this state has previously replayed nothing for two months without alerting, because the one rule aimed squarely at that condition had no series to evaluate.
+
+## Diagnosis
+
+The alert labels carry the `namespace`, `cluster` and `pod`.
+
+- Confirm the collector is up but erroring. `cnpg_collector_up` reads 1 and `cnpg_collector_last_collection_error` reads 1 at the same time, which is the whole signature:
+
+```bash
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_up|cnpg_collector_last_collection_error"
+```
+
+- Find which query is failing. The instance logs name both the query and the database it could not reach:
+
+```bash
+kubectl logs -n <namespace> pod/<instance-pod-name> --tail=200 | grep -i "error collecting"
+```
+
+A line naming a `targetDatabase` the cluster does not have is the common case:
+
+```
+"Error collecting user query","query":"pg_settings","targetDatabase":"app"
+```
+
+- Check what the application database is actually called. The collector queries the name in `.spec.bootstrap.initdb.database`, and a cluster bootstrapped without one gets `app` by default:
+
+```bash
+kubectl get -n <namespace> cluster/paradedb -o jsonpath='{.spec.bootstrap.initdb.database}'
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- psql -lqt | cut -d '|' -f 1
+```
+
+If the two disagree, that is the fault. A dedicated replica declared as its own cluster is the easiest place to get this wrong, because the database name has to be repeated there and is easy to leave out.
+
+- Confirm which series are actually missing, so you know what was unmonitored:
+
+```bash
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -cE "cnpg_pg_replication_lag|cnpg_pg_replication_streaming_replicas"
+```
+
+- On a standby, check from the primary whether replication is healthy, since the lag alerts could not have told you:
+
+```bash
+kubectl exec -n <namespace> -it services/paradedb-rw -- psql -c "
+SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;
+"
+```
+
+## Mitigation
+
+- If the application database name is wrong, correct it on the cluster and let the operator roll the change out. On a dedicated replica, set it to the same name the source cluster uses.
+
+- If the failure is a custom monitoring query rather than a default one, disable that instrumentation under `.spec.monitoring` until a fixed version is rolled out. The default collectors keep working, so the alerts above stay live.
+
+- If a collector query is blocked rather than erroring outright, terminate the backend holding it up:
+
+```bash
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- psql -c "
+SELECT pid, state, wait_event_type, wait_event,
+       now() - query_start AS duration, left(query, 120) AS query
+FROM pg_stat_activity
+WHERE state <> 'idle'
+ORDER BY duration DESC NULLS LAST;
+"
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- psql -c "SELECT pg_terminate_backend(<pid>);"
+```
+
+The alert resolves once a collection completes without error. Confirm the missing series are back:
+
+```bash
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_last_collection_error|cnpg_pg_replication_lag"
+```
+
+Afterwards, audit whether any replication or HA alert should have fired while the series were missing, and for how long they had been missing before this alert existed. Escalate if the collection error persists after the database name is correct, if it appears across several instances at once, which suggests a bad instrumentation rollout rather than one misconfigured cluster, or if `pg_stat_replication` on the primary shows a standby that has not been replaying.

--- a/charts/paradedb/prometheus_rules/cluster-instance_metrics_failing.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-instance_metrics_failing.yaml
@@ -1,0 +1,22 @@
+{{- $alert := "CNPGInstanceMetricsFailing" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: ParadeDB CNPG metrics collector is failing its queries
+  description: |-
+    ParadeDB CNPG instance "{{ .namespace }}/{{ .labels.pod }}" is answering on its metrics endpoint, but its most recent collection ended in an error, so part of what it should be publishing is missing.
+
+    This is the counterpart to CNPGInstanceMetricsAbsent. There the exporter is unreachable and the gap is obvious. Here it responds normally and only the queries behind individual metrics fail, so nothing reports the instance as down.
+
+    The alerts that read the missing series have no samples to evaluate and cannot fire. Their silence means nothing for this instance while this is active.
+
+    The usual cause is the collector being unable to reach the cluster's application database, which fails every default per-database query at once while the exporter itself stays healthy.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGInstanceMetricsFailing.md
+expr: |
+  cnpg_collector_last_collection_error{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 1
+for: 15m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

`CNPGInstanceMetricsFailing`, critical, `for: 15m`, and its runbook.

```promql
cnpg_collector_last_collection_error{namespace="...",pod=~"..."} == 1
```

## Why

`CNPGInstanceMetricsAbsent` covers an exporter that stops responding, which is visible from outside. Nothing covers one that responds normally while the queries behind individual metrics fail.

That second case is how a dedicated replica replayed nothing for two months without paging anyone. The collector could not reach the cluster's application database, so every default per-database query failed:

```
FATAL:  database "app" does not exist
"Error collecting user query","query":"pg_settings","targetDatabase":"app"
```

`cnpg_pg_replication_lag` was therefore never published, and `CNPGClusterPhysicalReplicationLagCritical` is a `> threshold` rule — with no samples it produces nothing rather than firing. It failed open, silently, and it was the rule aimed squarely at that incident. `CNPGInstanceMetricsAbsent` could not help either: the exporter process was alive and still reporting `cnpg_collector_up`.

CNPG already exports `cnpg_collector_last_collection_error` for precisely this condition. It is already scraped and already on the ParadeDB dashboard (`paradedb-dashboard.json:9766`). **No alert rule in this repo or in paradedb/mcc reads it.**

## How

`cnpg_collector_last_collection_error` is a single gauge per instance, `1` when the last collection ended in an error. `for: 15m` rides out one failed cycle, a restart or a failover, so what fires is persistent rather than transient — which is what the incident looked like.

`severity: critical` matches `CNPGInstanceMetricsAbsent`. The consequence is the same: alerts that read the affected series cannot fire, and their silence stops meaning anything.

The runbook leads with the application database name, since that is the known cause, and points out that a dedicated replica declared as its own cluster is the easiest place to get it wrong. It also asks the responder to audit what went unmonitored, because by the time this fires the gap is already in the past.

## Tests

The rule renders to valid YAML through the same `tpl` context `templates/prometheus-rule.yaml` builds, with `.namespace`, `.cluster`, `.podSelector` and `.labels.pod` substituted as the template does. Every `runbook_url` across all 22 rules resolves to a file that exists, including this one. The runbook follows the four-section standard, with no em dashes and no long-form `kubectl` flags.

Not run: `helm template`. `get.helm.sh` is blocked by this environment's network policy. The `monitoring` chainsaw test is the real check, and it is the only test that sets `monitoring.enabled: true`, so it is the only one that renders `prometheus_rules/` at all.

## Notes

This is the unblocked half of paradedb/mcc#175. The other half of that issue wanted a replay-distance metric from charts#220, which was closed as unnecessary — the root cause was the misconfigured replica, not missing instrumentation, and that has since been fixed in paradedb/cloud. What survives is the guard against the rule failing open, which needs no new instrumentation at all. The matching MCC rule follows separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvSeRGRYLarQDkoNS8Vmhb)_