### PR TITLE
fix: give replica clusters an application database name

### DIFF
--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -372,7 +372,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | recovery.s3.secretKey | string | `""` |  |
 | recovery.secret.create | bool | `true` | Whether to create a secret for the backup credentials |
 | recovery.secret.name | string | `""` | Name of the backup credentials secret |
-| replica.bootstrap.database | string | `""` | Name of the database used by the application |
+| replica.bootstrap.database | string | `"paradedb"` | Name of the database used by the application. Default: `paradedb`. Must match the application database of the origin cluster: CNPG falls back to `app` when this is empty, and the metrics exporter then connects to a database that does not exist on the replica, which fails every SQL-backed metric. |
 | replica.bootstrap.owner | string | `""` | Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key. |
 | replica.bootstrap.secret | string | `""` | Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch |
 | replica.bootstrap.source | string | `""` | One of `object_store` or `pg_basebackup`. Method to use for bootstrap. |

--- a/charts/paradedb/docs/runbooks/CNPGInstanceMetricsFailing.md
+++ b/charts/paradedb/docs/runbooks/CNPGInstanceMetricsFailing.md
@@ -22,13 +22,19 @@ A standby in this state has previously replayed nothing for two months without a
 
 The alert labels carry the `namespace`, `cluster` and `pod`.
 
-- Confirm the collector is up but erroring. `cnpg_collector_up` reads 1 and `cnpg_collector_last_collection_error` reads 1 at the same time, which is the whole signature:
+- Confirm the collector is up but erroring. `cnpg_collector_up` reads 1 while one of the two error flags reads 1, which is the whole signature. The flags cover different work: `cnpg_collector_last_collection_error` is the collector's own, `cnpg_last_error` is the SQL it runs against the databases. Failing queries set only the second one, so check both:
 
 ```bash
-kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_up|cnpg_collector_last_collection_error"
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_up|cnpg_collector_last_collection_error|cnpg_last_error"
 ```
 
-- Find which query is failing. The instance logs name both the query and the database it could not reach:
+- Find which query is failing. Every failure is published as a `cnpg_errors_total` series whose `errorUserQueries` label names the query, the database it ran against and the error:
+
+```bash
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep cnpg_errors_total
+```
+
+One failing query is a broken instrumentation query, often one naming a relation that has since been dropped. Every query failing at once on the same database is the collector being unable to reach that database at all. The instance logs say the same thing:
 
 ```bash
 kubectl logs -n <namespace> pod/<instance-pod-name> --tail=200 | grep -i "error collecting"
@@ -40,14 +46,15 @@ A line naming a `targetDatabase` the cluster does not have is the common case:
 "Error collecting user query","query":"pg_settings","targetDatabase":"app"
 ```
 
-- Check what the application database is actually called. The collector queries the name in `.spec.bootstrap.initdb.database`, and a cluster bootstrapped without one gets `app` by default:
+- Check what the application database is actually called. The collector queries the name the cluster declares in its bootstrap section, and a cluster bootstrapped without one gets `app` by default:
 
 ```bash
-kubectl get -n <namespace> cluster/paradedb -o jsonpath='{.spec.bootstrap.initdb.database}'
+# Whichever of the three the cluster bootstrapped with; a replica cluster uses recovery or pg_basebackup.
+kubectl get -n <namespace> cluster/<cluster-name> -o jsonpath='{.spec.bootstrap}'
 kubectl exec -n <namespace> -it pod/<instance-pod-name> -- psql -lqt | cut -d '|' -f 1
 ```
 
-If the two disagree, that is the fault. A dedicated replica declared as its own cluster is the easiest place to get this wrong, because the database name has to be repeated there and is easy to leave out.
+If the two disagree, that is the fault. A dedicated replica declared as its own cluster is the easiest place to get this wrong, because the database name has to be repeated there and is easy to leave out. With this chart, that name comes from `replica.bootstrap.database`.
 
 - Confirm which series are actually missing, so you know what was unmonitored:
 
@@ -65,7 +72,7 @@ SELECT application_name, state, replay_lsn, replay_lag FROM pg_stat_replication;
 
 ## Mitigation
 
-- If the application database name is wrong, correct it on the cluster and let the operator roll the change out. On a dedicated replica, set it to the same name the source cluster uses.
+- If the application database name is wrong, correct it on the cluster and let the operator roll the change out. On a dedicated replica, set `replica.bootstrap.database` to the same name the source cluster uses.
 
 - If the failure is a custom monitoring query rather than a default one, disable that instrumentation under `.spec.monitoring` until a fixed version is rolled out. The default collectors keep working, so the alerts above stay live.
 
@@ -85,7 +92,7 @@ kubectl exec -n <namespace> -it pod/<instance-pod-name> -- psql -c "SELECT pg_te
 The alert resolves once a collection completes without error. Confirm the missing series are back:
 
 ```bash
-kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_last_collection_error|cnpg_pg_replication_lag"
+kubectl exec -n <namespace> -it pod/<instance-pod-name> -- curl -sS --max-time 5 http://localhost:9187/metrics | grep -E "cnpg_collector_last_collection_error|cnpg_last_error|cnpg_pg_replication_lag"
 ```
 
 Afterwards, audit whether any replication or HA alert should have fired while the series were missing, and for how long they had been missing before this alert existed. Escalate if the collection error persists after the database name is correct, if it appears across several instances at once, which suggests a bad instrumentation rollout rather than one misconfigured cluster, or if `pg_stat_replication` on the primary shows a standby that has not been replaying.

--- a/charts/paradedb/test/replica/04-replica_cluster-assert.yaml
+++ b/charts/paradedb/test/replica/04-replica_cluster-assert.yaml
@@ -3,6 +3,12 @@ kind: Cluster
 metadata:
   name: replica-paradedb
 spec:
+  bootstrap:
+    pg_basebackup:
+      source: originCluster
+      # The metrics exporter connects to this database, so it must be set: CNPG otherwise defaults it
+      # to `app`, which does not exist on a replica of a ParadeDB cluster.
+      database: paradedb
   replica:
     enabled: true
     source: originCluster

--- a/charts/paradedb/test/replica/06-replica_object_store_cluster-assert.yaml
+++ b/charts/paradedb/test/replica/06-replica_object_store_cluster-assert.yaml
@@ -3,6 +3,12 @@ kind: Cluster
 metadata:
   name: replica-object-store-paradedb
 spec:
+  bootstrap:
+    recovery:
+      source: originCluster
+      # The metrics exporter connects to this database, so it must be set: CNPG otherwise defaults it
+      # to `app`, which does not exist on a replica of a ParadeDB cluster.
+      database: paradedb
   replica:
     enabled: true
     source: originCluster

--- a/charts/paradedb/test/replica/08-replica_hybrid_cluster-assert.yaml
+++ b/charts/paradedb/test/replica/08-replica_hybrid_cluster-assert.yaml
@@ -6,6 +6,9 @@ spec:
   bootstrap:
     recovery:
       source: originCluster
+      # The metrics exporter connects to this database, so it must be set: CNPG otherwise defaults it
+      # to `app`, which does not exist on a replica of a ParadeDB cluster.
+      database: paradedb
   replica:
     enabled: true
     source: originCluster

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -540,8 +540,10 @@ replica:
   bootstrap:
     # -- One of `object_store` or `pg_basebackup`. Method to use for bootstrap.
     source: ""
-    # -- Name of the database used by the application
-    database: ""
+    # -- Name of the database used by the application. Default: `paradedb`. Must match the application database of
+    # the origin cluster: CNPG falls back to `app` when this is empty, and the metrics exporter then connects to a
+    # database that does not exist on the replica, which fails every SQL-backed metric.
+    database: paradedb
     # -- Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
     secret: ""
     # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.


### PR DESCRIPTION
## What

`replica.bootstrap.database` defaulted to `""`, so CNPG fell back to its own default of `app` on every replica cluster this chart renders. `recovery.database` and `recovery.pgBaseBackup.database` already default to `paradedb`; this was the one bootstrap path left out.

## Why

Nothing creates an `app` database on a replica, and the metrics exporter connects to the cluster's application database to run its queries. So every SQL-backed collector fails at once while the exporter itself keeps answering and reports no error of its own:

```
cnpg_errors_total{errorUserQueries="pg_database on db app: failed to connect to `user=postgres database=app`:
                  FATAL: database \"app\" does not exist (SQLSTATE 3D000)"}
```

Fourteen such errors on the affected instance — `pg_database`, `pg_stat_database`, `pg_replication`, `pg_settings`, `pg_stat_archiver`, `pg_stat_subscription`, `pg_extensions`, `backends`. Comparing the series a replica publishes against its source cluster: **137 metric names on the source, 64 on the replica**, and the 73 missing are every `cnpg_pg_*`, `cnpg_backends_*` and `cnpg_paradedb_*` series.

The consequence is not just blank dashboards. The lag and HA alerts are all `expr > threshold` rules, so with no series to evaluate they produce nothing rather than firing — they fail open. A customer's dedicated replica stopped replaying for two weeks and nothing said so.

## Changes

- `replica.bootstrap.database` defaults to `paradedb`, with a comment on why it cannot be left empty. README regenerated with helm-docs.
- The three replica chainsaw asserts now check the rendered `database` on the Cluster, so this cannot silently regress. Verified all three render `database: paradedb` under `bootstrap.recovery` / `bootstrap.pg_basebackup`.
- `CNPGInstanceMetricsFailing` runbook corrected. It told the on-call to confirm the failure via `cnpg_collector_last_collection_error`, which stays **0** in this scenario — the flag that reads 1 is `cnpg_last_error`. It also pointed at `.spec.bootstrap.initdb.database`, which a replica cluster does not have. It now names `cnpg_errors_total` as the fastest way to see which query failed and against which database.

## Note on existing clusters

Applying this to an already-bootstrapped replica needs a check: the instance manager reads the application database name from the spec at runtime, but bootstrap fields are otherwise only consumed at bootstrap. Roll it to one cluster and confirm `cnpg_errors_total` clears before doing the rest.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4