### PR TITLE
fix: stop the backup tiles reporting a fault on clusters that take no backups

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -972,7 +972,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Elapsed time since the last successful base backup.",
+      "description": "Elapsed time since the last successful base backup. A cluster that takes none of its own, such as a dedicated replica, reports N/A instead of an age.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -981,10 +981,20 @@
           "mappings": [
             {
               "options": {
+                "-1": {
+                  "color": "text",
+                  "index": 0,
+                  "text": "N/A"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
                 "from": 1,
                 "result": {
                   "color": "semi-dark-orange",
-                  "index": 0,
+                  "index": 1,
                   "text": "Invalid date"
                 },
                 "to": 1e+42
@@ -996,7 +1006,7 @@
                 "from": -2147483648,
                 "result": {
                   "color": "red",
-                  "index": 1,
+                  "index": 2,
                   "text": "N/A"
                 },
                 "to": -1577847600
@@ -1066,7 +1076,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "-(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\",pod=~\"$instances\"}))",
+          "expr": "(-(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\",pod=~\"$instances\"} > 0))) or on() vector(-1)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1400,7 +1410,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Base Backups are considered healthy when there has been at least one base backup in the last 24 hours.",
+      "description": "Base Backups are considered healthy when there has been at least one base backup in the last 24 hours. A cluster that takes none of its own, such as a dedicated replica, reports N/A instead of an age.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1409,10 +1419,20 @@
           "mappings": [
             {
               "options": {
+                "-1": {
+                  "color": "text",
+                  "index": 0,
+                  "text": "N/A"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
                 "match": "null",
                 "result": {
                   "color": "orange",
-                  "index": 0,
+                  "index": 1,
                   "text": "None"
                 }
               },
@@ -1423,7 +1443,7 @@
                 "from": 0,
                 "result": {
                   "color": "green",
-                  "index": 1,
+                  "index": 2,
                   "text": "Healthy"
                 },
                 "to": 90000
@@ -1435,7 +1455,7 @@
                 "from": 90000,
                 "result": {
                   "color": "orange",
-                  "index": 2,
+                  "index": 3,
                   "text": "Degraded"
                 },
                 "to": 108000
@@ -1447,7 +1467,7 @@
                 "from": 108000,
                 "result": {
                   "color": "red",
-                  "index": 3,
+                  "index": 4,
                   "text": "None recent"
                 },
                 "to": 4294967295
@@ -1560,7 +1580,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\", pod=~\"$instances\"})",
+          "expr": "(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\", pod=~\"$instances\"} > 0)) or on() vector(-1)",
           "legendFormat": "Backups",
           "range": true,
           "refId": "BACKUPS"


### PR DESCRIPTION
Follow-up to #228, covering the user-facing dashboard this chart ships.

## What

Both base-backup panels read `cnpg_collector_last_available_backup_timestamp`, which is **0** on an instance that has no backup of its own. `time() - 0` is roughly 56 years, so:

- **Last Base Backup** (panel 360) fell into its `[-2147483648, -1577847600]` range and showed a red N/A.
- The **backup status tile** (panel 588) fell past `108000` and showed a red "None recent".

Every dedicated replica renders both of those permanently, and neither is a fault: a replica runs with `backups.enabled: false` because its data is backed up by the cluster it replicates.

## The fix

Filter zero timestamps and fall back to a `-1` sentinel, mapped to a neutral N/A. Same treatment already merged for the MCC dashboard in paradedb/mcc#228.

Checked against live data for a source cluster and its dedicated replica:

| | panel 360 | panel 588 |
|---|---|---|
| source cluster | `-5248.9` → green age | `3105` → green Healthy |
| dedicated replica | `-1` → neutral N/A | `-1` → neutral N/A |

A cluster that does take backups is unchanged, and one that takes them but has fallen behind still goes orange and then red. The existing red N/A range is kept, since it still catches a genuinely bogus timestamp rather than an absent one.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4