### PR TITLE
fix: read logical replication lag from the columns the chart already publishes

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -2936,7 +2936,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(clamp_min(timestamp(cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\"}) - cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\"},0))",
+          "expr": "max(clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\"},0))",
           "instant": false,
           "legendFormat": "Replication Lag",
           "range": true,
@@ -3017,7 +3017,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(abs(cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\"} - cnpg_pg_stat_subscription_latest_end_lsn{namespace=\"$namespace\"}))",
+          "expr": "max(abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\"}))",
           "instant": false,
           "legendFormat": "LSN Distance",
           "range": true,
@@ -3339,7 +3339,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "min(avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\",worker_type=\"apply\"} - cnpg_pg_stat_subscription_latest_end_lsn{namespace=\"$namespace\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((time() - cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120))))",
+          "expr": "min(avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120))))",
           "legendFormat": "Logical Replication SLO 99.9% < 500MB",
           "range": true,
           "refId": "SLO"
@@ -4571,7 +4571,7 @@
         {
           "editorMode": "code",
           "exemplar": false,
-          "expr": "clamp_min(timestamp(cnpg_pg_stat_subscription_last_msg_receipt_time) - cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)",
+          "expr": "clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -4585,7 +4585,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} - cnpg_pg_stat_subscription_latest_end_lsn",
+          "expr": "cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"}",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -4600,7 +4600,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by (subname) \n(\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} - cnpg_pg_stat_subscription_latest_end_lsn < bool 500 * 1024 * 1024)[$__range]\n            )[$__interval]\n        )\n    )\n    *\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (time() - cnpg_pg_stat_subscription_last_msg_receipt_time {namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 120)[$__range]\n            )[$__interval]\n        )\n    )\n    * \n    on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\",cluster=\"$cluster\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\"))\n)[7d]",
+          "expr": "avg by (subname) \n(\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 500 * 1024 * 1024)[$__range]\n            )[$__interval]\n        )\n    )\n    *\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 120)[$__range]\n            )[$__interval]\n        )\n    )\n    * \n    on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\",cluster=\"$cluster\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\"))\n)[7d]",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -4767,7 +4767,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (subname,worker_type)(max_over_time(cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\"} - cnpg_pg_stat_subscription_latest_end_lsn{namespace=\"$namespace\"}))",
+          "expr": "max by (subname,worker_type)(max_over_time(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\"}))",
           "legendFormat": "{{subname}}",
           "range": true,
           "refId": "A"
@@ -4858,7 +4858,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (subname,worker_type)(deriv(cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\",job=\"$namespace/$cluster\"} - cnpg_pg_stat_subscription_latest_end_lsn))",
+          "expr": "avg by (subname,worker_type)(deriv(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\"}))",
           "legendFormat": "{{subname}} ({{type}})",
           "range": true,
           "refId": "A"
@@ -4957,7 +4957,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by(subname, worker_type) (max_over_time(clamp_min(timestamp(cnpg_pg_stat_subscription_last_msg_receipt_time) - cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)[$__rate_interval]))*1000",
+          "expr": "max by(subname, worker_type) (max_over_time(clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)[$__rate_interval]))*1000",
           "legendFormat": "{{subname}} ({{type}})",
           "range": true,
           "refId": "A"
@@ -5067,7 +5067,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_received_lsn{namespace=\"$namespace\",worker_type=\"apply\"} - cnpg_pg_stat_subscription_latest_end_lsn{namespace=\"$namespace\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((time() - cnpg_pg_stat_subscription_last_msg_receipt_time{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120)))",
+          "expr": "avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120)))",
           "legendFormat": "{{subname}}",
           "range": true,
           "refId": "SLO"
@@ -8628,12 +8628,114 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 158
+      },
+      "id": 834,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (pod, datname) (rate(cnpg_pg_stat_database_blks_hit{namespace=~\"$namespace\",pod=~\"$instances\",datname!=\"\",datname!~\"template.*\"}[$__rate_interval]))\n/\n(\n  sum by (pod, datname) (rate(cnpg_pg_stat_database_blks_hit{namespace=~\"$namespace\",pod=~\"$instances\",datname!=\"\",datname!~\"template.*\"}[$__rate_interval]))\n  +\n  sum by (pod, datname) (rate(cnpg_pg_stat_database_blks_read{namespace=~\"$namespace\",pod=~\"$instances\",datname!=\"\",datname!~\"template.*\"}[$__rate_interval]))\n)",
+          "interval": "",
+          "legendFormat": "{{datname}} ({{pod}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Ratio",
+      "type": "timeseries",
+      "description": "Share of block reads served from the buffer cache rather than from disk, per database. Template databases and the shared-objects row are excluded."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 158
+        "y": 166
       },
       "id": 827,
       "panels": [],
@@ -8700,7 +8802,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 159
+        "y": 167
       },
       "id": 828,
       "options": {
@@ -8722,7 +8824,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (node) (rate(container_network_receive_bytes_total{}[$__rate_interval])) * on(node) group_left(pod) kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\", node=\"$nodes\"}",
+          "expr": "sum by (node) (rate(container_network_receive_bytes_total{node=~\"$nodes\"}[$__rate_interval])) * on(node) group_left(pod) kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\", node=~\"$nodes\"}",
           "legendFormat": "{{node}} ({{pod}}) (RX)",
           "range": true,
           "refId": "RX"
@@ -8733,7 +8835,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "- sum by (node) (rate(container_network_transmit_bytes_total{}[$__rate_interval])) * on(node) group_left(pod) kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\", node=\"$nodes\"}",
+          "expr": "- sum by (node) (rate(container_network_transmit_bytes_total{node=~\"$nodes\"}[$__rate_interval])) * on(node) group_left(pod) kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\", node=~\"$nodes\"}",
           "hide": false,
           "instant": false,
           "legendFormat": "{{node}} ({{pod}}) (TX)",
@@ -8741,7 +8843,7 @@
           "refId": "TX"
         }
       ],
-      "title": "Network Throughout: $nodes",
+      "title": "Network Throughput: $nodes",
       "type": "timeseries"
     },
     {
@@ -8750,7 +8852,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 169
+        "y": 177
       },
       "id": 37,
       "panels": [],
@@ -8820,7 +8922,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 170
+        "y": 178
       },
       "id": 6,
       "options": {
@@ -8928,7 +9030,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 170
+        "y": 178
       },
       "id": 52,
       "options": {
@@ -9038,7 +9140,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 170
+        "y": 178
       },
       "id": 53,
       "options": {
@@ -9134,7 +9236,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 178
+        "y": 186
       },
       "id": 725,
       "options": {
@@ -9174,7 +9276,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 186
+        "y": 194
       },
       "id": 18,
       "panels": [],
@@ -9249,7 +9351,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 187
+        "y": 195
       },
       "id": 16,
       "options": {
@@ -9347,7 +9449,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 187
+        "y": 195
       },
       "id": 14,
       "options": {
@@ -9446,7 +9548,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 187
+        "y": 195
       },
       "id": 59,
       "options": {
@@ -9546,7 +9648,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 187
+        "y": 195
       },
       "id": 20,
       "options": {
@@ -9587,7 +9689,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 195
+        "y": 203
       },
       "id": 231,
       "panels": [],
@@ -9618,7 +9720,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 196
+        "y": 204
       },
       "id": 233,
       "options": {
@@ -9739,7 +9841,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 196
+        "y": 204
       },
       "id": 235,
       "options": {
@@ -9778,7 +9880,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 204
+        "y": 212
       },
       "id": 239,
       "panels": [],
@@ -9849,7 +9951,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 205
+        "y": 213
       },
       "id": 237,
       "options": {
@@ -9889,7 +9991,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 211
+        "y": 219
       },
       "id": 293,
       "panels": [],
@@ -9961,7 +10063,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 212
+        "y": 220
       },
       "id": 295,
       "options": {
@@ -10076,7 +10178,7 @@
         "h": 6,
         "w": 5,
         "x": 5,
-        "y": 212
+        "y": 220
       },
       "id": 296,
       "options": {
@@ -10132,7 +10234,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 218
+        "y": 226
       },
       "id": 794,
       "panels": [],
@@ -10216,7 +10318,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 219
+        "y": 227
       },
       "id": 792,
       "options": {
@@ -10301,7 +10403,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 227
+        "y": 235
       },
       "id": 696,
       "panels": [],
@@ -10359,7 +10461,7 @@
         "h": 2,
         "w": 4,
         "x": 0,
-        "y": 228
+        "y": 236
       },
       "id": 697,
       "options": {
@@ -10461,7 +10563,7 @@
         "h": 2,
         "w": 4,
         "x": 4,
-        "y": 228
+        "y": 236
       },
       "id": 702,
       "options": {
@@ -10563,7 +10665,7 @@
         "h": 2,
         "w": 4,
         "x": 8,
-        "y": 228
+        "y": 236
       },
       "id": 698,
       "options": {
@@ -10665,7 +10767,7 @@
         "h": 2,
         "w": 4,
         "x": 12,
-        "y": 228
+        "y": 236
       },
       "id": 704,
       "options": {
@@ -10767,7 +10869,7 @@
         "h": 2,
         "w": 4,
         "x": 16,
-        "y": 228
+        "y": 236
       },
       "id": 703,
       "options": {
@@ -10891,7 +10993,7 @@
         "h": 8,
         "w": 4,
         "x": 0,
-        "y": 230
+        "y": 238
       },
       "id": 746,
       "options": {
@@ -11021,7 +11123,7 @@
         "h": 8,
         "w": 4,
         "x": 4,
-        "y": 230
+        "y": 238
       },
       "id": 767,
       "options": {
@@ -11150,7 +11252,7 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 230
+        "y": 238
       },
       "id": 768,
       "options": {
@@ -11279,7 +11381,7 @@
         "h": 8,
         "w": 4,
         "x": 12,
-        "y": 230
+        "y": 238
       },
       "id": 790,
       "options": {
@@ -11410,7 +11512,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 230
+        "y": 238
       },
       "id": 769,
       "options": {


### PR DESCRIPTION
Ports a change the MCC dashboard made in an internal PR and this one never picked up, plus two things found while comparing the two.

## Logical replication panels

Eight panels derived subscription lag in PromQL: LSN distance as `received_lsn - latest_end_lsn`, message age as `timestamp(m) - m` or `time() - m`. The chart's own `monitoring-logical-replication.yaml` already publishes both, computed in SQL:

```sql
CASE WHEN received_lsn IS NOT NULL AND latest_end_lsn IS NOT NULL
     THEN GREATEST(0, pg_wal_lsn_diff(received_lsn, latest_end_lsn))
     ELSE NULL END AS buffered_lag_bytes
...
EXTRACT(EPOCH FROM (NOW() - last_msg_receipt_time)) AS receipt_lag_seconds
```

Panels changed: ids 797, 798, 799, 802, 803, 820, 831, 832. Each keeps its existing aggregation and only swaps the underlying expression — no SLO or window math was touched.

Checked against a live cluster with 24 subscriptions:

| | old | new |
|---|---|---|
| LSN distance | `0` (24 series) | `0` (24 series) |
| Message receipt age | `0` | `0.013s` |

Distance is identical on a healthy cluster, and now cannot go negative when a subscription reports `latest_end` ahead of `received`. Message age is the real gain: the PromQL form measures against the sample timestamp, so any sub-second lag clamps to a flat `0`. The column reports what the database actually observed.

## Network Throughput panel

`Network Throughout: $nodes` — misspelled, and it matched its own repeat variable with `node="$nodes"` where the variable is `multi` + `includeAll` and can interpolate to a regex. It also rated `container_network_*_bytes_total{}` across every container in the cluster and then discarded all but one node in the join. The filter now sits in the selector. Verified identical output on a live node: 25.63 MiB/s before and after.

## Cache Hit Ratio panel

New, in the Storage I/O row. The dashboard had no cache-hit panel — the closest was Block I/O, which plots raw `blks_hit` and `blks_read` counters.

```
sum by (pod, datname) (rate(cnpg_pg_stat_database_blks_hit{...}[$__rate_interval]))
/ (sum by (pod, datname) (rate(blks_hit)) + sum by (pod, datname) (rate(blks_read)))
```

Rows below it shift down by 8, which is most of the diff's line count.

## Something to look at separately

`Block I/O [5m]`, `Tuple I/O [5m]` and `Temp Bytes [5m]` all select `datname=""`. That is not an instance total — it is `pg_stat_database`'s shared-objects row, where `datname` is NULL. On a live cluster:

```
blks_hit rate by datname:  (empty) 39.2  |  paradedb 233.0  |  paradedb_production 1996.3  |  postgres 73.4
```

So those three panels plot roughly 2% of the real activity. That is inherited from upstream and affects panels this PR does not otherwise touch, so I left them alone — the new Cache Hit Ratio panel uses `datname!=""` instead. Worth its own change if you agree with the reading.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4