### PR TITLE
fix: make the dashboard's rollup expressions valid PromQL

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -3359,7 +3359,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "min(avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120))))",
+          "expr": "min(avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120)[$__range:])))",
           "legendFormat": "Logical Replication SLO 99.9% < 500MB",
           "range": true,
           "refId": "SLO"
@@ -4787,7 +4787,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (subname,worker_type)(max_over_time(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\"}))",
+          "expr": "max by (subname,worker_type)(max_over_time(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{subname}}",
           "range": true,
           "refId": "A"
@@ -4878,7 +4878,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (subname,worker_type)(deriv(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\"}))",
+          "expr": "avg by (subname,worker_type)(deriv(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\"}[$__rate_interval]))",
           "legendFormat": "{{subname}} ({{type}})",
           "range": true,
           "refId": "A"
@@ -5087,7 +5087,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120)))",
+          "expr": "avg by (subname) (avg_over_time(((abs(cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",worker_type=\"apply\"})) < BOOL 500*1024*1024)[$__range:])) * avg by (subname) (avg_over_time((cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",worker_type=\"apply\"} < BOOL 120)[$__range:]))",
           "legendFormat": "{{subname}}",
           "range": true,
           "refId": "SLO"
@@ -8074,7 +8074,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(sum by (instance) (node_disk_read_bytes_total) * on(instance) group_left(nodename) node_uname_info) * on(nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$instances\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
+          "expr": "sum by (instance) (rate(node_disk_read_bytes_total[$__rate_interval])) * on(instance) group_left(nodename) node_uname_info * on(nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$instances\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -8173,7 +8173,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(sum by (instance) (node_disk_written_bytes_total) * on(instance) group_left(nodename) node_uname_info) * on(nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$instances\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
+          "expr": "sum by (instance) (rate(node_disk_written_bytes_total[$__rate_interval])) * on(instance) group_left(nodename) node_uname_info * on(nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$instances\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -8272,7 +8272,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (customer,instance) (max_over_time(rate(node_disk_reads_completed_total+node_disk_writes_completed_total)[$__rate_interval])[$__interval]) * on(instance,customer) group_left(nodename) node_uname_info{} * on(customer,nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$cluster-([1-9][0-9]*)$\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
+          "expr": "max by (instance) (max_over_time((sum by (instance) (rate(node_disk_reads_completed_total[$__rate_interval]) + rate(node_disk_writes_completed_total[$__rate_interval])))[$__interval:])) * on(instance) group_left(nodename) node_uname_info * on(nodename) group_left(pod) label_replace(kube_pod_info{pod=~\"$instances\", namespace=\"$namespace\"}, \"nodename\", \"$1\", \"node\", \"(.*)\")",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{pod}}",


### PR DESCRIPTION
Finding 1 of three from an audit of this dashboard against the internal one. Companion: paradedb/mcc#230.

## What

Seven targets call a rollup function on an instant vector:

| panel | expression |
|---|---|
| LSN Distance | `max_over_time(cnpg_pg_stat_subscription_buffered_lag_bytes{...})` |
| LSN Distance Growth Rate | `deriv(cnpg_pg_stat_subscription_buffered_lag_bytes{...})` |
| Logical Replication SLO (stat and timeseries) | `avg_over_time((… < BOOL 120))` |
| Disk IO (Read) / (Write) | `rate(sum by (instance) (counter) * on(instance) group_left(nodename) …)` |
| Disk IOPS | `max_over_time(rate(a + b)[…])[…]` |

VictoriaMetrics accepts every one of these through implicit lookbehind, which is why they render on our own stack. **This dashboard ships to users running whatever Prometheus they have**, and Prometheus rejects a rollup over an instant vector as a type error — `expected type range vector … got instant vector`. Those panels draw nothing for them.

## The fix

The four subscription panels take an explicit range or subquery.

The three disk panels move `rate()` onto the counter itself. That is not only a syntax fix: `rate(sum(counter))` rates a sum of per-device counters, so a device that resets or disappears reads as a decrease across the whole sum. `sum(rate(counter[…]))` handles each device's resets independently.

Disk IOPS also dropped a `customer` label matcher that came along when these panels were adapted from the internal dashboard — no chart user has that label — and now selects instances the way its two sibling panels do.

## Numbers move where the maths was wrong

Checked against a live three-instance cluster:

| | old | new |
|---|---|---|
| Disk IOPS | 36.5 / 32.6 / 36.9 | 67.9 / 63.8 / 71.6 |
| LSN Distance | 8 series, 0 B | 8 series, 0 B |
| SLO | 1.0 | 1.0 |

The IOPS difference is the point: the new value is the peak of the summed read and write rates, which is what the panel says it shows. The subscription panels are unchanged in value and only differ in being expressible on Prometheus.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4