### PR TITLE
fix: select the operator by label, and match a multi-value variable as a regex

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -1857,7 +1857,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+\", condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", condition=\"true\"} * on (namespace, pod) group_left() kube_pod_labels{namespace=\"$operatorNamespace\", label_app_kubernetes_io_name=\"cloudnative-pg\"})",
           "hide": false,
           "instant": true,
           "legendFormat": "Operator Status",
@@ -5383,7 +5383,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\",relname=\"$bm25_indicies\"}) by (le)",
+          "expr": "avg(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\",relname=~\"$bm25_indicies\"}) by (le)",
           "format": "heatmap",
           "legendFormat": "{{relname}}",
           "range": true,
@@ -10510,7 +10510,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+\", condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", condition=\"true\"} * on (namespace, pod) group_left() kube_pod_labels{namespace=\"$operatorNamespace\", label_app_kubernetes_io_name=\"cloudnative-pg\"})",
           "hide": false,
           "instant": true,
           "legendFormat": "Ready Operator Pods",
@@ -11037,7 +11037,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", pod=~\"cloudnative-pg-operator.+\", condition=\"true\"})",
+          "expr": "sum(kube_pod_status_ready{namespace=\"$operatorNamespace\", condition=\"true\"} * on (namespace, pod) group_left() kube_pod_labels{namespace=\"$operatorNamespace\", label_app_kubernetes_io_name=\"cloudnative-pg\"})",
           "hide": false,
           "instant": false,
           "legendFormat": "Ready Operator Pods",


### PR DESCRIPTION
Finding 3 of three. Companion for the variable matcher in the internal dashboard: paradedb/mcc#231.

## Operator panels

`Operator Status`, `Ready Operator Pods` (stat) and `Ready Operator Pods` (timeseries) all select:

```
kube_pod_status_ready{namespace="$operatorNamespace", pod=~"cloudnative-pg-operator.+", condition="true"}
```

`cloudnative-pg-operator` is the name of *our* Helm release. It is not something CloudNativePG guarantees — a user who installs the operator under any other release name, which the upstream chart's own examples do, gets three permanently empty panels and no indication why.

The operator's pods carry `app.kubernetes.io/name=cloudnative-pg` regardless of release name, so the panels join on that:

```
sum(kube_pod_status_ready{namespace="$operatorNamespace", condition="true"}
    * on (namespace, pod) group_left()
    kube_pod_labels{namespace="$operatorNamespace", label_app_kubernetes_io_name="cloudnative-pg"})
```

Verified identical on a live cluster — 10 ready operator pods before and after. This is how the internal dashboard has always selected it.

## Heatmap variable

The `$bm25_indicies segments` heatmap matched `relname="$bm25_indicies"`. That variable is `multi` with `includeAll`, so it can interpolate to `(index_a|index_b)`, which an exact match never finds. It works today only because the panel repeats and each copy receives a single value — the moment anything reads it without repeating, it silently returns nothing. Now `=~`.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4