### PR TITLE
fix: give the remaining subqueries their step separator

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -4620,7 +4620,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg by (subname) \n(\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 500 * 1024 * 1024)[$__range]\n            )[$__interval]\n        )\n    )\n    *\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 120)[$__range]\n            )[$__interval]\n        )\n    )\n    * \n    on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\",cluster=\"$cluster\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\"))\n)[7d]",
+          "expr": "avg by (subname) \n(\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_buffered_lag_bytes{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 500 * 1024 * 1024)[$__range:]\n            )[$__interval:]\n        )\n    )\n    *\n    avg by (subname, pod) (\n        last_over_time(\n            avg_over_time(\n                (cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"} < bool 120)[$__range:]\n            )[$__interval:]\n        )\n    )\n    * \n    on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\",cluster=\"$cluster\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\"))\n)[7d:]",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -4977,7 +4977,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by(subname, worker_type) (max_over_time(clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)[$__rate_interval]))*1000",
+          "expr": "max by(subname, worker_type) (max_over_time(clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{namespace=\"$namespace\",job=\"$namespace/$cluster\",worker_type=\"apply\"},0)[$__rate_interval:]))*1000",
           "legendFormat": "{{subname}} ({{type}})",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Follow-up to #233, which fixed the rollups called on instant vectors but missed a second way the same panels are invalid on Prometheus.

## What

A subquery is `expr[range:step]`. Written as `expr[range]`, the brackets are a **range selector**, and those are only legal directly on a vector selector. So Prometheus rejects both of these outright:

```
(abs(cnpg_pg_stat_subscription_buffered_lag_bytes{...}) < bool 500*1024*1024)[$__range]
clamp_min(cnpg_pg_stat_subscription_receipt_lag_seconds{...}, 0)[$__rate_interval]
```

MetricsQL accepts them and supplies the step, which is why the Subscriptions table and Last Message Receipt Age render on our stack and would not on a user's.

Six occurrences across two panels: five in `Subscriptions` (its SLO column, including the trailing `[7d]`) and one in `Last Message Receipt Age`.

## Values are unchanged

Both forms resolve to the same step under VictoriaMetrics. Checked on a live cluster with 8 subscriptions:

| | `[range]` | `[range:]` |
|---|---|---|
| SLO fraction | 1.0 × 8 | 1.0 × 8 |
| receipt age | 0.0277 … 0.0278 | 0.0277 … 0.0278 |

Identical to four decimal places. After this, the dashboard has no colon-less subqueries left.

The same defect is in the internal dashboard in more places (its two SLO panels, its Subscriptions table and its Last Message Receipt Age) and is fixed there in paradedb/mcc#232.

Related: paradedb/mcc#179

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4