### PR TITLE
feat: bring the MCC's remaining relevant panels into the user-facing dashboard

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5172,7 +5172,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 46
       },
@@ -5266,8 +5266,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 46
       },
       "id": 808,
@@ -5312,6 +5312,105 @@
       ],
       "title": "Segment size",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 46
+      },
+      "id": 835,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (relname) (cnpg_paradedb_index_relation_size * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "legendFormat": "{{relname}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Relation size",
+      "type": "timeseries",
+      "description": "On-disk size of each BM25 index, read from the current primary."
     },
     {
       "datasource": {
@@ -11565,6 +11664,120 @@
       ],
       "title": "Pooler Reconcile Errors",
       "type": "timeseries"
+    },
+    {
+      "id": 837,
+      "type": "row",
+      "title": "Kubernetes Nodes",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 246
+      }
+    },
+    {
+      "id": 836,
+      "type": "state-timeline",
+      "title": "Node Conditions",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Conditions reported by the nodes running this cluster. A node under disk, memory or PID pressure evicts pods and stalls Postgres before anything in the database itself looks wrong.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 247
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "refId": "A",
+          "legendFormat": "{{node}} · {{condition}}",
+          "expr": "avg by (node, condition) (kube_node_status_condition{condition!=\"Ready\", status=\"false\", node=~\"$nodes\"} * on (node) group_left() max by (node) (kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\"}))"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "refId": "B",
+          "legendFormat": "{{node}} · {{condition}}",
+          "expr": "avg by (node, condition) (kube_node_status_condition{condition=\"Ready\", status=\"true\", node=~\"$nodes\"} * on (node) group_left() max by (node) (kube_pod_info{namespace=~\"$namespace\", pod=~\"$instances\"}))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "fixed"
+          },
+          "custom": {
+            "fillOpacity": 100,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "UNHEALTHY"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "OK"
+                }
+              }
+            }
+          ],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "always",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      }
     }
   ],
   "preload": false,

--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5410,7 +5410,7 @@
       ],
       "title": "Relation size",
       "type": "timeseries",
-      "description": "On-disk size of each BM25 index, read from the current primary."
+      "description": "On-disk size of each ParadeDB index, read from the current primary."
     },
     {
       "datasource": {


### PR DESCRIPTION
Toward paradedb/mcc#196 — the "customers see the same stuff we see" half of it.

## Method

Comparing the two dashboards by panel title is misleading: the MCC's header tiles are untitled, and several panels exist in both under different names. So I compared them by **which metrics each one reads**. That leaves exactly two things the MCC surfaces that a self-hosted operator cannot see here.

## Ported

**Relation size** — `cnpg_paradedb_index_relation_size`, the on-disk size of a BM25 index. The chart already publishes this from its own instrumentation and already charts `Segment count` and `Segment size` beside it, so the index was described in every way except how big it is. The three now share a line as thirds; nothing below them moves. Verified against a live cluster: `nonprofits_search_idx`, 312.7 MiB.

**Node Conditions** — `kube_node_status_condition`: disk, memory and PID pressure, plus readiness, for the nodes running the cluster. A node under pressure evicts pods and stalls Postgres well before anything in the database itself looks wrong, and nothing else here shows it.

One deliberate difference from the MCC's version: that one repeats a panel per node, which is fine on a cell we dedicate to one database and awful on a cluster where the user runs their own workloads too. This is a single panel joined to the nodes actually hosting instances. On a live cluster that narrows 4 nodes and 12 series to the 3 nodes and 9 series that matter.

## Deliberately not ported

**Global CPU Usage** and **Global RAM Usage** — whole-Kubernetes-cluster utilisation against requests and limits, including Windows node variants. That is capacity planning for a cell we dedicate to one database. On a shared cluster it would describe something other than ParadeDB, on a dashboard the user opens to look at ParadeDB.

Happy to add them if you disagree — it is two bargauges.

## Already at parity

Everything else the MCC reads is here, in some cases named differently: memory working set, volume space (data and WAL), database size deltas, physical replication lag, per-node network throughput, cluster instance status via `kube_customresource_instances_status_*`, the logical replication SLO, storage classes, installed extensions, long-running queries and cache hit ratio. The chart additionally reads 24 metrics the MCC does not.

## Still open on #196

This covers panel parity. The other two parts are untouched: splitting our dashboard from the upstream CNPG one so the diff stays reviewable (paradedb/terraform-paradedb-byoc#781), and whatever PG18 changes.

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4