### PR TITLE
docs: call them ParadeDB indexes, not BM25 indexes

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5477,19 +5477,19 @@
         }
       },
       "pluginVersion": "11.5.1",
-      "repeat": "bm25_indicies",
+      "repeat": "paradedb_indexes",
       "repeatDirection": "h",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\",relname=~\"$bm25_indicies\"}) by (le)",
+          "expr": "avg(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\",relname=~\"$paradedb_indexes\"}) by (le)",
           "format": "heatmap",
           "legendFormat": "{{relname}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "$bm25_indicies segments",
+      "title": "$paradedb_indexes segments",
       "type": "heatmap"
     },
     {
@@ -11906,7 +11906,7 @@
         "definition": "label_values(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\"},relname)",
         "hide": 2,
         "includeAll": true,
-        "name": "bm25_indicies",
+        "name": "paradedb_indexes",
         "options": [],
         "query": {
           "qryType": 1,


### PR DESCRIPTION
We renamed the indexes; the dashboard had not caught up. Companion: paradedb/mcc#233.

## Changed

- The dashboard variable `bm25_indicies` is now `paradedb_indexes` — 4 occurrences: the variable itself, the panel that repeats over it, its title (`$paradedb_indexes segments`) and its query. The rename also drops the misspelling of "indices".

Rebased onto `dev` after #239 merged. The three README lines this PR originally carried are now on `dev` via that PR, along with the `README.md.gotmpl` and root `README.md` copies they are generated from — without those, the next `make docs` run would have reverted the README half of this rename. The rebase dropped the duplicated README hunk cleanly, so this PR is now the dashboard JSON only.

## Deliberately unchanged

`USING bm25`, `amname = 'bm25'` in the index instrumentation query, and `paradedb.create_bm25_test_table` in the chainsaw tests. `bm25` is still the name of the access method in SQL — renaming it in a monitoring query would simply break the query, and renaming it in a test would break the test.

Saved dashboard URLs carrying `var-bm25_indicies=…` will fall back to the variable's default, which is the only user-visible consequence.

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4