### PR TITLE
docs: rename BM25 indexes to ParadeDB indexes in README sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cnpg/cloudnative-pg
 #### Setting up a ParadeDB CNPG Cluster
 
 > [!IMPORTANT]
-> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of BM25 indexes across instances.
+> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of ParadeDB indexes across instances.
 > Using ParadeDB Enterprise requires an access token. To request one, please [contact sales](mailto:sales@paradedb.com).
 
 Create a `values.yaml` and configure it to your requirements. Here is a basic example:

--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -33,7 +33,7 @@ cnpg/cloudnative-pg
 #### Setting up a ParadeDB CNPG Cluster
 
 > [!IMPORTANT]
-> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of BM25 indexes across instances.
+> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of ParadeDB indexes across instances.
 > Using ParadeDB Enterprise requires an access token. To request one, please [contact sales](mailto:sales@paradedb.com).
 
 Create a `values.yaml` and configure it to your requirements. Here is a basic example:
@@ -155,7 +155,7 @@ There is a separate document outlining the recovery procedure here: **[Recovery]
 
 The ParadeDB Helm chart supports monitoring with Prometheus and Grafana. The chart includes a comprehensive Grafana dashboard that provides complete monitoring for both PostgreSQL/cluster operations and ParadeDB-specific search and analytics features. The dashboard is provisioned as a ConfigMap that works with the Grafana sidecar to automatically import dashboards. You can enable this by setting `monitoring.grafanaDashboard.create`.
 
-**Note:** This is a complete, all-in-one dashboard that includes both standard CloudNativePG monitoring (replication, backups, storage, WAL, connections) and ParadeDB-specific metrics (pg_search, BM25 search, index segments). You do not need to install any additional dashboards.
+**Note:** This is a complete, all-in-one dashboard that includes both standard CloudNativePG monitoring (replication, backups, storage, WAL, connections) and ParadeDB-specific metrics (pg_search, ParadeDB indexes, index segments). You do not need to install any additional dashboards.
 
 ### Dashboard Features
 
@@ -170,7 +170,7 @@ The comprehensive dashboard includes monitoring for:
 - Logical replication metrics
 
 **ParadeDB Search & Analytics:**
-- BM25 index segments and sizes
+- ParadeDB index segments and sizes
 - `pg_search` performance metrics
 - Search-specific analytics
 - Index layer monitoring

--- a/charts/paradedb/README.md.gotmpl
+++ b/charts/paradedb/README.md.gotmpl
@@ -33,7 +33,7 @@ cnpg/cloudnative-pg
 #### Setting up a ParadeDB CNPG Cluster
 
 > [!IMPORTANT]
-> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of BM25 indexes across instances.
+> When deploying a cluster with more than one instance, you must use `type: paradedb-enterprise` to enable replication of ParadeDB indexes across instances.
 > Using ParadeDB Enterprise requires an access token. To request one, please [contact sales](mailto:sales@paradedb.com).
 
 Create a `values.yaml` and configure it to your requirements. Here is a basic example:
@@ -155,7 +155,7 @@ There is a separate document outlining the recovery procedure here: **[Recovery]
 
 The ParadeDB Helm chart supports monitoring with Prometheus and Grafana. The chart includes a comprehensive Grafana dashboard that provides complete monitoring for both PostgreSQL/cluster operations and ParadeDB-specific search and analytics features. The dashboard is provisioned as a ConfigMap that works with the Grafana sidecar to automatically import dashboards. You can enable this by setting `monitoring.grafanaDashboard.create`.
 
-**Note:** This is a complete, all-in-one dashboard that includes both standard CloudNativePG monitoring (replication, backups, storage, WAL, connections) and ParadeDB-specific metrics (pg_search, BM25 search, index segments). You do not need to install any additional dashboards.
+**Note:** This is a complete, all-in-one dashboard that includes both standard CloudNativePG monitoring (replication, backups, storage, WAL, connections) and ParadeDB-specific metrics (pg_search, ParadeDB indexes, index segments). You do not need to install any additional dashboards.
 
 ### Dashboard Features
 
@@ -170,7 +170,7 @@ The comprehensive dashboard includes monitoring for:
 - Logical replication metrics
 
 **ParadeDB Search & Analytics:**
-- BM25 index segments and sizes
+- ParadeDB index segments and sizes
 - `pg_search` performance metrics
 - Search-specific analytics
 - Index layer monitoring


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Applies the "BM25 indexes" → "ParadeDB indexes" rename from #238 to the two places it was missed:

- `charts/paradedb/README.md.gotmpl` — all 3 lines (replication note, monitoring note, dashboard feature list)
- root `README.md` — the replication note, which is duplicated there

Also carries the same 3 `charts/paradedb/README.md` lines as #238 so this branch is self-consistent against `dev`; the content is byte-identical, so whichever merges first the other is a no-op.

## Why

`charts/paradedb/README.md` is generated from `README.md.gotmpl` by helm-docs (`make docs` in the `Makefile`). Editing only the generated file means the next docs run silently reverts the rename. The root `README.md` is hand-maintained and carries its own copy of the replication note, so it drifts independently.

## How

Text-only substitution across the three files. No template logic, values, chart manifests, or dashboard JSON touched.

Left alone, matching #238's reasoning: `USING bm25` and `amname = 'bm25'` in `templates/monitoring-paradedb-index.yaml`, `paradedb.create_bm25_test_table` in the chainsaw tests, and the `USING bm25` example in `docs/long-running-tasks.md`. `bm25` is still the SQL access method name — renaming it there would break the query, the tests, and the documented example.

## Tests

Prose-only change with no runtime effect. Verified `grep -rn 'BM25\|bm25'` returns nothing in the three touched files, and that `templates/paradedb-dashboard.yaml` pulls the dashboard via `.Files.Get "monitoring/paradedb-dashboard.json"` — a single copy, so no other dashboard file needs the variable rename from #238.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194r4k1Jw1wZeA1LxHh3FCk)_