### PR TITLE
fix: make the Database Size tile report one number, the current total

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -2232,7 +2232,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "sum"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -2250,11 +2250,11 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "cnpg_pg_database_size_bytes{namespace=\"$namespace\", pod=~\"$instances\"}",
+          "expr": "sum(max by (datname) (cnpg_pg_database_size_bytes{namespace=\"$namespace\", pod=~\"$instances\"}))",
           "format": "table",
-          "instant": false,
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],


### PR DESCRIPTION
The second of the two items shelved during the dashboard audit.

## Problem

The header's Database Size tile queried:

```
cnpg_pg_database_size_bytes{namespace="$namespace", pod=~"$instances"}
```

with `range: true` and a `sum` reduction. Three problems compound:

1. **Unaggregated** — one series per database per instance. On a live three-instance cluster with four databases that is **12 series**, rendered into a tile two grid rows tall.
2. **Summed over the range** — a `sum` reduction on a range query adds up every sample in the window, so a size gauge becomes a number that grows with your chosen time range and resolution. It does not describe the databases at all.
3. **Summed across instances** — a replicated database counts once per instance.

## Fix

```
sum(max by (datname) (cnpg_pg_database_size_bytes{namespace="$namespace", pod=~"$instances"}))
```

with `lastNotNull` and an instant query. Each database counts once, at its size on the instance that reports the largest value, and the tile shows the current total. On a live cluster it reads **632.6 GB**, which matches that cluster's data.

This is what the internal dashboard's equivalent tile has always done; the sibling Database Size timeseries in the Storage row already aggregates `max by (datname)` and is unaffected.

Related: paradedb/mcc#196

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4