### PR TITLE
feat: pick up upstream's dashboard fixes, and add a way to spot the next ones

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -1076,7 +1076,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(-(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\",pod=~\"$instances\"} > 0))) or on() vector(-1)",
+          "expr": "(-(time() - max({__name__=~\"cnpg_collector_last_available_backup_timestamp|barman_cloud_cloudnative_pg_io_last_available_backup_timestamp\",namespace=\"$namespace\",pod=~\"$instances\"} > 0))) or on() vector(-1)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1580,7 +1580,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(time() - max(cnpg_collector_last_available_backup_timestamp{namespace=\"$namespace\", pod=~\"$instances\"} > 0)) or on() vector(-1)",
+          "expr": "(time() - max({__name__=~\"cnpg_collector_last_available_backup_timestamp|barman_cloud_cloudnative_pg_io_last_available_backup_timestamp\",namespace=\"$namespace\",pod=~\"$instances\"} > 0)) or on() vector(-1)",
           "legendFormat": "Backups",
           "range": true,
           "refId": "BACKUPS"
@@ -2359,7 +2359,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(cnpg_collector_first_recoverability_point{namespace=~\"$namespace\",pod=~\"$instances\"})*1000",
+          "expr": "max({__name__=~\"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point\",namespace=~\"$namespace\",pod=~\"$instances\"})*1000",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -7538,7 +7538,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max by (datname) (cnpg_pg_database_size_bytes{namespace=\"$namespace\", pod=~\"$instances\"})",
+          "expr": "max by (datname) (cnpg_pg_database_size_bytes{datname!~\"template.*\",datname!=\"postgres\",namespace=~\"$namespace\",pod=~\"$instances\"})",
           "format": "time_series",
           "instant": false,
           "legendFormat": "__auto",
@@ -10094,7 +10094,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (pod) (cnpg_collector_first_recoverability_point{namespace=~\"$namespace\",pod=~\"$instances\"}*1000 > 0)",
+          "expr": "max by (pod) ({__name__=~\"cnpg_collector_first_recoverability_point|barman_cloud_cloudnative_pg_io_first_recoverability_point\",namespace=~\"$namespace\",pod=~\"$instances\"}*1000 > 0)",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -10206,7 +10206,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (pod) ({__name__=~\"cnpg_pg_stat_(bgwriter|checkpointer)_checkpoints_req\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "expr": "sum by (pod) (rate({__name__=~\"cnpg_pg_stat_(bgwriter|checkpointer)_checkpoints_req\",namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -10221,7 +10221,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (pod) ({__name__=~\"cnpg_pg_stat_(bgwriter|checkpointer)_checkpoints_timed\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "expr": "sum by (pod) (rate({__name__=~\"cnpg_pg_stat_(bgwriter|checkpointer)_checkpoints_timed\",namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -10321,7 +10321,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (pod) ({__name__=~\"cnpg_pg_stat_(bgwriter_checkpoint|checkpointer)_write_time\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "expr": "sum by (pod) (rate({__name__=~\"cnpg_pg_stat_(bgwriter_checkpoint|checkpointer)_write_time\",namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -10336,7 +10336,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "max by (pod) ({__name__=~\"cnpg_pg_stat_(bgwriter_checkpoint|checkpointer)_sync_time\",namespace=~\"$namespace\",pod=~\"$instances\"})",
+          "expr": "sum by (pod) (rate({__name__=~\"cnpg_pg_stat_(bgwriter_checkpoint|checkpointer)_sync_time\",namespace=~\"$namespace\",pod=~\"$instances\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
Our dashboard began as a copy of the CloudNativePG cluster dashboard — which no longer lives in `cloudnative-pg/charts` at all, but in [cloudnative-pg/grafana-dashboards](https://github.com/cloudnative-pg/grafana-dashboards). Upstream has moved on since we forked, and nothing told us what we were missing.

## Taken from upstream

**Barman Cloud plugin metrics.** CNPG is migrating backups out of the in-tree barman support and into the Barman Cloud plugin, which publishes the same values under `barman_cloud_cloudnative_pg_io_*`. Four panels — Last Base Backup, the backup status tile, and both First Recoverability Point panels — now match either name:

```
{__name__=~"cnpg_collector_last_available_backup_timestamp|barman_cloud_cloudnative_pg_io_last_available_backup_timestamp", ...}
```

Without this, a cluster that moves to the plugin sees its backup panels quietly empty. Our own `> 0` guard and N/A fallback are kept on top.

**Checkpoints as rates.** `Requested/Timed` and `Write/Sync time` plotted raw counters, so the lines only ever climbed. They are rates now (upstream's #59), combined with our per-pod aggregation.

**Database Size drops template and postgres**, matching what the Δsize tiles beside it already did.

Every expression verified against a live cluster with the variables interpolated — all seven panels return data, and the Write/Sync time panel now reads ~0.9s of write time per second rather than a cumulative total.

## Deliberately not taken

Upstream matches the operator by pod name (`cloudnative-pg.+|cnpg-controller-manager.+`), where we join on the `app.kubernetes.io/name` label — ours survives a differently named Helm release, theirs does not. Their per-pod panels are also still unaggregated, and their per-database stats still read the shared-objects row. We fixed both, and both are now open upstream as [PR #70](https://github.com/cloudnative-pg/grafana-dashboards/pull/70) and [issue #71](https://github.com/cloudnative-pg/grafana-dashboards/issues/71).

## Noticing the next ones

`make dashboard-drift` fetches upstream's dashboard and prints what they have that we lack, plus which shared panel ids have differing queries. Today it reports 3 missing and 56 differing, most of which are our deliberate divergences and renumbered ids.

It only reports. Whether a difference is ours on purpose or something to pick up is a judgement call, so nothing is applied automatically.

Related: paradedb/mcc#196

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4