### PR TITLE
fix: page at the same thresholds and in the same units as the fleet

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-high_connection-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-high_connection-critical.yaml
@@ -4,10 +4,10 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance maximum number of connections critical!
   description: |-
-    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" instance {{ .labels.pod }} is using {{ .value }}% of the maximum number of connections.
+    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" instance {{ .labels.pod }} is using {{ .valuePercent }} of the maximum number of connections.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHighConnections.md
 expr: |
-  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 95
+  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 0.95
 for: 5m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-high_connection-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-high_connection-warning.yaml
@@ -4,10 +4,10 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance is approaching the maximum number of connections.
   description: |-
-    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" instance {{ .labels.pod }} is using {{ .value }}% of the maximum number of connections.
+    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" instance {{ .labels.pod }} is using {{ .valuePercent }} of the maximum number of connections.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHighConnections.md
 expr: |
-  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 80
+  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 0.8
 for: 5m
 labels:
   severity: warning

--- a/charts/paradedb/prometheus_rules/cluster-low_disk_space-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-low_disk_space-critical.yaml
@@ -4,18 +4,18 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance is running out of disk space!
   description: |-
-    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is running extremely low on disk space. Check attached PVCs! Current disk space usage is {{ .value }}% of the total capacity.
+    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is running extremely low on disk space. Check attached PVCs! Current disk space usage is {{ .valuePercent }} of the total capacity.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterLowDiskSpace.md
 expr: |
-  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) * 100 > 90 OR
-  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) * 100 > 90 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.9 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) > 0.9 OR
   max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
       /
       sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
       *
       on(namespace, persistentvolumeclaim) group_left(volume)
       kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
-  ) * 100 > 90
+  ) > 0.9
 for: 5m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-low_disk_space-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-low_disk_space-warning.yaml
@@ -4,18 +4,18 @@ alert: {{ $alert }}
 annotations:
   summary: ParadeDB Instance is running out of disk space.
   description: |-
-    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is running low on disk space. Check attached PVCs. Current disk space usage is {{ .value }}% of the total capacity.
+    ParadeDB CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is running low on disk space. Check attached PVCs. Current disk space usage is {{ .valuePercent }} of the total capacity.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterLowDiskSpace.md
 expr: |
-  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) * 100 > 80 OR
-  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) * 100 > 80 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.8 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) > 0.8 OR
   max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
       /
       sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
       *
       on(namespace, persistentvolumeclaim) group_left(volume)
       kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
-  ) * 100 > 80
+  ) > 0.8
 for: 5m
 labels:
   severity: warning

--- a/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-critical.yaml
@@ -4,12 +4,12 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster very high physical replication lag
   description: |-
-    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is experiencing a very high physical replication lag of {{ .value }}ms.
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is experiencing a very high physical replication lag of {{ .value }}s.
 
     High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
 expr: |
-  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 15
+  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 600
 for: 5m
 labels:
   severity: critical

--- a/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-warning.yaml
@@ -4,12 +4,12 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster high physical replication lag
   description: |-
-    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is experiencing a high physical replication lag of {{ .value }}ms.
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" is experiencing a high physical replication lag of {{ .value }}s.
 
     High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
 expr: |
-  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 1
+  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 5
 for: 5m
 labels:
   severity: warning

--- a/charts/paradedb/templates/prometheus-rule.yaml
+++ b/charts/paradedb/templates/prometheus-rule.yaml
@@ -15,6 +15,7 @@ spec:
       rules:
         {{- $dict := dict "excludeRules" .Values.cluster.monitoring.prometheusRule.excludeRules -}}
         {{- $_ := set $dict "value"       "{{ $value }}" -}}
+        {{- $_ := set $dict "valuePercent" "{{ $value | humanizePercentage }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
         {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}") -}}


### PR DESCRIPTION
Part of paradedb/mcc#184, item 2. Companion rename: paradedb/mcc#235.

## Physical replication lag: the real gap

| | before | after |
| --- | --- | --- |
| warning | `> 1` | `> 5` |
| critical | `> 15` | `> 600` |

A self-hosted user was paged at 15 seconds of replication lag, on a metric that moves for a checkpoint or a busy standby — while we would not have looked until 600. Both now use the fleet's numbers, which came out of actually running these clusters.

## Connections and disk space: same threshold, two conventions

These only looked divergent. The chart computed a percentage and compared against 80; the fleet compares a ratio against 0.8. Identical in effect, but you had to decode each expression to see it. They are ratios now, so the two rule sets diff cleanly.

That exposed the descriptions, which said `{{ $value }}%` and would now render "0.85%". They use `humanizePercentage`, as the fleet's rules already do. That needed a `valuePercent` key alongside `value` in the rule template's context, since `value` is injected as the literal `{{ $value }}` and cannot be piped at the call site.

## Also fixed

Both physical replication lag descriptions reported the lag in **ms**. `cnpg_pg_replication_lag` is in seconds, so a 600 second lag was described as "600ms" — three orders of magnitude off, in the sentence the on-call reads first.

## Verified

All six rules rendered from the chart:

```
CNPGClusterHighConnectionsWarning        > 0.8    "... is using {{ $value | humanizePercentage }} of the maximum ..."
CNPGClusterHighConnectionsCritical       > 0.95
CNPGClusterLowDiskSpaceWarning           > 0.8    "... Current disk space usage is {{ $value | humanizePercentage }} ..."
CNPGClusterLowDiskSpaceCritical          > 0.9
CNPGClusterPhysicalReplicationLagWarning  > 5     "... physical replication lag of {{ $value }}s ..."
CNPGClusterPhysicalReplicationLagCritical > 600
```

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4