### PR TITLE
ci: fail the build when a rule links to a runbook that does not exist

### DIFF
--- a/.github/scripts/check_runbook_links.py
+++ b/.github/scripts/check_runbook_links.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Check that every alert rule links to a runbook that exists in this repository.
+
+A rule and the runbook it points at are edited separately, so a link breaks quietly:
+the rule renders, the alert fires, and the on-call follows a 404 at the worst moment.
+
+The rules are Helm templates rather than plain YAML, so they are read with a regex.
+That is enough here — the alert name and the runbook link are both literals.
+
+Note this deliberately does not flag runbooks that nothing links to. The MCC has its
+own rules against these same runbooks, and it is private, so this repository cannot
+see the full set of references. That check lives there instead.
+
+Usage: check_runbook_links.py
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2] / "charts" / "paradedb"
+RULES = ROOT / "prometheus_rules"
+RUNBOOKS = ROOT / "docs" / "runbooks"
+PREFIX = "https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/"
+
+ALERT = re.compile(r'\$alert\s*:=\s*"([^"]+)"')
+LINK = re.compile(r"runbook_url:\s*(\S+)")
+
+
+def main():
+    problems = []
+    checked = 0
+
+    for path in sorted(RULES.glob("*.yaml")):
+        text = path.read_text()
+        alert = ALERT.search(text)
+        name = alert.group(1) if alert else path.name
+
+        link = LINK.search(text)
+        if not link:
+            problems.append(f"{name}: no runbook_url")
+            continue
+
+        url = link.group(1)
+        if not url.startswith(PREFIX):
+            problems.append(f"{name}: runbook_url does not point at this repository's runbooks: {url}")
+            continue
+
+        runbook = RUNBOOKS / url[len(PREFIX):]
+        if not runbook.is_file():
+            problems.append(f"{name}: runbook does not exist: {runbook.relative_to(ROOT.parent.parent)}")
+        checked += 1
+
+    print(f"checked {checked} rules against {len(list(RUNBOOKS.glob('*.md')))} runbooks")
+    for problem in problems:
+        print(f"::error::{problem}")
+
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-runbook-links.yml
+++ b/.github/workflows/check-runbook-links.yml
@@ -1,0 +1,36 @@
+# workflows/check-runbook-links.yml
+#
+# Check Runbook Links
+# Fail the build when an alert rule links to a runbook that does not exist.
+
+name: Check Runbook Links
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/scripts/check_runbook_links.py"
+      - ".github/workflows/check-runbook-links.yml"
+      - "charts/paradedb/prometheus_rules/**"
+      - "charts/paradedb/docs/runbooks/**"
+  workflow_dispatch:
+
+concurrency:
+  group: check-runbook-links-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-runbook-links:
+    name: Check Every Rule Links to a Runbook That Exists
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Check Runbook Links
+        run: python3 .github/scripts/check_runbook_links.py


### PR DESCRIPTION
Part of paradedb/mcc#184, item 4 — the half that can run here.

## Why

A rule and the runbook it points at are edited separately, so a broken link is silent: the rule still renders, the alert still fires, and the on-call follows a 404 at the worst possible moment. Nothing in this repository checked it. The MCC has had this check since paradedb/mcc#225, but it only covers the MCC's own rules.

## What it checks

Every rule in `charts/paradedb/prometheus_rules/` has a `runbook_url`, it points at this repository's runbook directory, and the file is there. Currently **22 rules against 17 runbooks**, passing.

The rules are Helm templates rather than plain YAML, so the script reads them with a regex — enough here, since the alert name and the runbook link are both literals.

Verified both ways: it passes on `dev`, and pointing one rule at `CNPGClusterLowDiskSpaceTypo.md` produces

```
::error::CNPGClusterLowDiskSpaceWarning: runbook does not exist: charts/paradedb/docs/runbooks/CNPGClusterLowDiskSpaceTypo.md
```

## What it deliberately does not check

Runbooks that nothing links to. Two of the seventeen — `CNPGBackupFailed.md` and `CNPGScheduledBackupStalled.md` — are linked only by the MCC's rules, which live in a private repository this build cannot read. An orphan check here would fail on runbooks that are in active use. That half belongs on the side that can see both rule sets, and is coming as a separate change there.

https://claude.ai/code/session_011QP2wJBfSCmLGs6CkN6hd4