### PR TITLE
feat(monitoring): alert on transaction ID wraparound

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGClusterXIDWraparound.md
+++ b/charts/paradedb/docs/runbooks/CNPGClusterXIDWraparound.md
@@ -1,0 +1,72 @@
+# CNPGClusterXIDWraparound
+
+## Description
+
+The `CNPGClusterXIDWraparoundWarning` and `CNPGClusterXIDWraparoundCritical` alerts fire when a database's transaction ID (`xid`) or multixact ID (`mxid`) age exceeds 1.5 billion or 2 billion, respectively. The `datname` label identifies the database and `age_kind` identifies which counter crossed the threshold.
+
+PostgreSQL must freeze old transaction IDs before they approach their finite limit. Autovacuum normally handles this automatically, but a long-running transaction, prepared transaction, replication slot, or lagging standby can prevent the freeze horizon from advancing.
+
+## Impact
+
+- Increasing age means PostgreSQL is losing the remaining safety margin before wraparound protection activates.
+- At roughly 2.1 billion transactions, PostgreSQL can refuse writes to prevent data loss.
+- Recovery after write protection activates can require downtime and manual vacuuming.
+
+## Diagnosis
+
+Check both ages for every database:
+
+```sql
+SELECT datname,
+       age(datfrozenxid) AS xid_age,
+       mxid_age(datminmxid) AS mxid_age
+FROM pg_database
+ORDER BY GREATEST(age(datfrozenxid), mxid_age(datminmxid)) DESC;
+```
+
+Find the oldest relations in the affected database:
+
+```sql
+SELECT c.oid::regclass AS relation,
+       age(c.relfrozenxid) AS xid_age,
+       mxid_age(c.relminmxid) AS mxid_age,
+       pg_size_pretty(pg_total_relation_size(c.oid)) AS size
+FROM pg_class AS c
+WHERE c.relkind IN ('r', 'm', 't')
+ORDER BY GREATEST(age(c.relfrozenxid), mxid_age(c.relminmxid)) DESC
+LIMIT 20;
+```
+
+Check for transactions and prepared transactions holding back the freeze horizon:
+
+```sql
+SELECT pid, state, backend_xmin, now() - xact_start AS transaction_age, query
+FROM pg_stat_activity
+WHERE xact_start IS NOT NULL
+ORDER BY xact_start;
+
+SELECT gid, prepared, owner, database
+FROM pg_prepared_xacts
+ORDER BY prepared;
+```
+
+Also inspect `pg_replication_slots` for old `xmin` or `catalog_xmin` values and verify that all CloudNativePG replicas are healthy and replaying WAL.
+
+## Mitigation
+
+Remove the condition holding back the freeze horizon before running a manual vacuum:
+
+- End abandoned long-running or idle-in-transaction sessions.
+- Resolve orphaned prepared transactions with `COMMIT PREPARED` or `ROLLBACK PREPARED` after confirming the intended outcome.
+- Restore an expected replication consumer or remove an abandoned logical slot after verifying it is no longer needed. Do not manually drop CloudNativePG-managed `_cnpg_` slots.
+- Repair or replace a lagging CloudNativePG replica rather than disabling `hot_standby_feedback` globally.
+
+After clearing the blocker, vacuum the oldest affected relations one at a time:
+
+```sql
+VACUUM (FREEZE, VERBOSE) <relation>;
+```
+
+Confirm that the database and relation ages are decreasing. Large relations can take significant time to vacuum, so continue monitoring available disk space and transaction ID age during recovery.
+
+Do not increase `autovacuum_freeze_max_age` to silence the alert. It does not change PostgreSQL's wraparound limit and delays the automatic vacuum intended to prevent this condition.

--- a/charts/paradedb/prometheus_rules/cluster-xid_wraparound-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-xid_wraparound-critical.yaml
@@ -1,0 +1,28 @@
+{{- $alert := "CNPGClusterXIDWraparoundCritical" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: PostgreSQL database is approaching transaction ID wraparound
+  description: |-
+    Database "{{ .labels.datname }}" in cluster "{{ .namespace }}/{{ .cluster }}" has a
+    {{ .labels.age_kind }} age of {{ .valueHuman }}. PostgreSQL can stop accepting writes at
+    roughly 2.1 billion if vacuum cannot advance the freeze horizon.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterXIDWraparound.md
+expr: |
+  max by (namespace, datname, age_kind) (
+    label_replace(
+      cnpg_pg_database_xid_age{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"},
+      "age_kind", "xid", "__name__", ".*"
+    )
+    or
+    label_replace(
+      cnpg_pg_database_mxid_age{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"},
+      "age_kind", "mxid", "__name__", ".*"
+    )
+  ) > 2000000000
+for: 15m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/prometheus_rules/cluster-xid_wraparound-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-xid_wraparound-warning.yaml
@@ -1,0 +1,28 @@
+{{- $alert := "CNPGClusterXIDWraparoundWarning" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: PostgreSQL database is approaching transaction ID wraparound
+  description: |-
+    Database "{{ .labels.datname }}" in cluster "{{ .namespace }}/{{ .cluster }}" has a
+    {{ .labels.age_kind }} age of {{ .valueHuman }}. PostgreSQL can stop accepting writes at
+    roughly 2.1 billion if vacuum cannot advance the freeze horizon.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterXIDWraparound.md
+expr: |
+  max by (namespace, datname, age_kind) (
+    label_replace(
+      cnpg_pg_database_xid_age{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"},
+      "age_kind", "xid", "__name__", ".*"
+    )
+    or
+    label_replace(
+      cnpg_pg_database_mxid_age{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"},
+      "age_kind", "mxid", "__name__", ".*"
+    )
+  ) > 1500000000
+for: 15m
+labels:
+  severity: warning
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/templates/prometheus-rule.yaml
+++ b/charts/paradedb/templates/prometheus-rule.yaml
@@ -15,10 +15,11 @@ spec:
       rules:
         {{- $dict := dict "excludeRules" .Values.cluster.monitoring.prometheusRule.excludeRules -}}
         {{- $_ := set $dict "value"       "{{ $value }}" -}}
+        {{- $_ := set $dict "valueHuman"  "{{ $value | humanize }}" -}}
         {{- $_ := set $dict "valuePercent" "{{ $value | humanizePercentage }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
-        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}") -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}" "datname" "{{ $labels.datname }}" "age_kind" "{{ $labels.age_kind }}") -}}
         {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "pvcSelector" (printf "%s-([1-9][0-9]*)" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "Values"      .Values -}}

--- a/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
@@ -45,6 +45,10 @@ spec:
 
               printf '%s\n' "$rendered" | grep -Fq 'persistentvolumeclaim=~"alerts-3-paradedb-([1-9][0-9]*)-wal"'
               printf '%s\n' "$rendered" | grep -Fq 'cnpg_pg_replication_in_recovery'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundWarning | grep -Fq 'cnpg_pg_database_xid_age'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundWarning | grep -Fq 'cnpg_pg_database_mxid_age'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundWarning | grep -Fq ') > 1500000000'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundCritical | grep -Fq ') > 2000000000'
 
               one_instance="$(render 1)"
               if printf '%s\n' "$one_instance" | grep -Fq 'CNPGClusterHA'; then
@@ -60,8 +64,14 @@ spec:
 
               excluded="$(render 3 \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[0]=CNPGReplicationSlotInactive' \
-                --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention')"
+                --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[2]=CNPGClusterXIDWraparoundWarning' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[3]=CNPGClusterXIDWraparoundCritical')"
               if printf '%s\n' "$excluded" | grep -Fq 'CNPGReplicationSlot'; then
                 echo "excluded replication slot alerts must not render"
+                exit 1
+              fi
+              if printf '%s\n' "$excluded" | grep -Fq 'CNPGClusterXIDWraparound'; then
+                echo "excluded transaction ID wraparound alerts must not render"
                 exit 1
               fi


### PR DESCRIPTION
## What

Adds chart-native warning and critical alerts for PostgreSQL transaction ID wraparound, plus a concise runbook.

| Alert | Threshold | For | Severity |
| --- | ---: | ---: | --- |
| `CNPGClusterXIDWraparoundWarning` | XID or MXID age > 1,500,000,000 | 15m | warning |
| `CNPGClusterXIDWraparoundCritical` | XID or MXID age > 2,000,000,000 | 15m | critical |

Both rules aggregate per database across cluster instances and retain an `age_kind` label identifying `xid` or `mxid`. They are scoped to the Helm release and support `excludeRules`.

## Why

PostgreSQL can refuse writes at roughly 2.1 billion transaction IDs to prevent wraparound. Autovacuum normally prevents this, but a pinned freeze horizon can let XID or multixact age increase silently until the database is close to an outage.

The warning identifies a database with diminishing headroom. The critical threshold indicates that wraparound protection is imminent and requires immediate intervention.

## Validation

- both alerts and thresholds covered by the shared Prometheus-rule rendering test
- both XID and MXID metric paths covered
- `excludeRules` covered
- `helm lint charts/paradedb`
- codespell, Markdown lint, and repository hooks