### PR TITLE
fix: raise physical replication lag warning threshold

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
+++ b/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
@@ -4,8 +4,8 @@
 
 The `CNPGClusterPhysicalReplicationLagWarning` and `CNPGClusterPhysicalReplicationLagCritical` alerts are triggered when the standby replicas fall too far behind the primary instance. Physical replication lag measures that distance in time.
 
-- **Warning level**: replication lag exceeds 1 second
-- **Critical level**: replication lag exceeds 15 seconds
+- **Warning level**: replication lag exceeds 60 seconds
+- **Critical level**: replication lag exceeds 600 seconds
 
 ## Impact
 

--- a/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-physical_replication_lag-warning.yaml
@@ -9,7 +9,7 @@ annotations:
     High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterPhysicalReplicationLag.md
 expr: |
-  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 5
+  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) > 60
 for: 5m
 labels:
   severity: warning


### PR DESCRIPTION
## Summary

- raise `CNPGClusterPhysicalReplicationLagWarning` from 5 seconds to 60 seconds
- retain the existing 600-second critical threshold
- update the runbook to document the 60-second warning and 600-second critical thresholds

This aligns the chart-managed alerts with the MCC VMRules and reduces noisy physical replication lag warnings.

## Validation

- `git diff --check`
- `helm lint charts/paradedb`