### PR TITLE
fix: make CNPG HA alerts instance-aware

### DIFF
--- a/charts/paradedb/prometheus_rules/cluster-ha-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-ha-critical.yaml
@@ -1,5 +1,5 @@
 {{- $alert := "CNPGClusterHACritical" -}}
-{{- if not (has $alert .excludeRules) -}}
+{{- if and (gt (int .Values.cluster.instances) 1) (not (has $alert .excludeRules)) -}}
 alert: {{ $alert }}
 annotations:
   summary: ParadeDB CNPG Cluster has no standby replicas!
@@ -9,8 +9,6 @@ annotations:
     The primary instance is still online and able to serve queries, although connections to the `-ro` endpoint will fail. The `-r` endpoint is operating at reduced capacity and all traffic is being served by the primary.
 
     This can happen during a normal fail-over or automated minor version upgrades in a cluster with 2 or less instances. The replaced instance may need some time to catch-up with the cluster primary instance.
-
-    This alarm will be constantly triggered if your cluster is configured to run with only 1 instance. If this is intentional, you may want to silence it.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHA.md
 expr: |
   max by (job) (

--- a/charts/paradedb/prometheus_rules/cluster-ha-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-ha-warning.yaml
@@ -1,14 +1,13 @@
 {{- $alert := "CNPGClusterHAWarning" -}}
-{{- if not (has $alert .excludeRules) -}}
+{{- $desiredStandbys := sub (int .Values.cluster.instances) 1 -}}
+{{- if and (gt $desiredStandbys 0) (not (has $alert .excludeRules)) -}}
 alert: {{ $alert }}
 annotations:
-  summary: ParadeDB CNPG Cluster less than 2 standby replicas.
+  summary: ParadeDB CNPG Cluster has fewer standby replicas than configured.
   description: |-
-    ParadeDB CloudNativePG Cluster "{{ .labels.job }}" has only {{ .value }} standby replicas, putting your cluster at risk if another instance fails. The cluster is still able to operate normally, although the `-ro` and `-r` endpoints are operating at reduced capacity.
+    ParadeDB CloudNativePG Cluster "{{ .labels.job }}" has only {{ .value }} of its {{ $desiredStandbys }} configured standby replicas, putting your cluster at risk if another instance fails. The cluster is still able to operate normally, although the `-ro` and `-r` endpoints are operating at reduced capacity.
 
     This can happen during a normal fail-over or automated minor version upgrades. The replaced instance may need some time to catch-up with the cluster primary instance.
-
-    This alarm will be constantly triggered if your cluster is configured to run with less than 3 instances. If this is intentional, you may want to silence it.
   runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterHA.md
 expr: |
   max by (job) (
@@ -19,7 +18,7 @@ expr: |
     )
     unless on (namespace, pod)
     (cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 1)
-  ) < 2
+  ) < {{ $desiredStandbys }}
 for: 5m
 labels:
   severity: warning

--- a/charts/paradedb/test/ha-alert-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/ha-alert-rendering/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ha-alert-rendering
+spec:
+  steps:
+    - name: Render desired-state-aware HA alerts
+      try:
+        - script:
+            content: |
+              set -eu
+
+              render() {
+                helm template "ha-$1" ../../ \
+                  --set "cluster.instances=$1" \
+                  --set cluster.monitoring.enabled=true \
+                  --set cluster.monitoring.prometheusRule.enabled=true \
+                  --show-only templates/prometheus-rule.yaml
+              }
+
+              alert_rule() {
+                awk -v alert="$1" '
+                  $0 ~ "- alert: " alert { printing = 1 }
+                  printing && $0 ~ /- alert:/ && $0 !~ ("- alert: " alert) { exit }
+                  printing { print }
+                '
+              }
+
+              one_instance="$(render 1)"
+              if printf '%s\n' "$one_instance" | grep -q 'CNPGClusterHA'; then
+                echo "single-instance clusters must not render HA alerts"
+                exit 1
+              fi
+
+              two_instances="$(render 2)"
+              printf '%s\n' "$two_instances" | alert_rule CNPGClusterHACritical | grep -q ') < 1'
+              printf '%s\n' "$two_instances" | alert_rule CNPGClusterHAWarning | grep -q ') < 1'
+
+              three_instances="$(render 3)"
+              printf '%s\n' "$three_instances" | alert_rule CNPGClusterHACritical | grep -q ') < 1'
+              printf '%s\n' "$three_instances" | alert_rule CNPGClusterHAWarning | grep -q ') < 2'


### PR DESCRIPTION
## What

Make the chart-provided CNPG HA alerts respect the configured cluster size.

- omit HA alerts for intentionally single-instance clusters
- derive the warning threshold from `cluster.instances - 1`
- keep the critical alert for multi-instance clusters with no standby
- remove guidance to manually silence intentional configurations
- add Helm rendering coverage for one-, two-, and three-instance clusters

## Why

The chart defaults to a single instance, but the existing HA rules always require one or two standbys. This causes both HA alerts to fire for a healthy, intentionally single-instance deployment.

## Validation

- `helm lint charts/paradedb`
- default `helm template` rendering
- HA regression checks for 1, 2, and 3 configured instances
- `git diff --check`