### PR TITLE
fix(monitoring): restore PostgreSQL 17 pg_stat_statements support

### DIFF
--- a/charts/paradedb/templates/monitoring-pg-stat-statements.yaml
+++ b/charts/paradedb/templates/monitoring-pg-stat-statements.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cluster.monitoring.instrumentation.pgStatStatements }}
+{{- /* This monitoring query only works on PostgreSQL 17+, where blk_*_time was renamed to shared_blk_*_time. */}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,10 +18,11 @@ data:
              , sum(s.rows) AS rows
              , sum(s.shared_blks_hit) AS shared_blks_hit
              , sum(s.shared_blks_read) AS shared_blks_read
-             , sum(s.blk_read_time) / 1000 AS blk_read_time_seconds
-             , sum(s.blk_write_time) / 1000 AS blk_write_time_seconds
+             , sum(s.shared_blk_read_time) / 1000 AS blk_read_time_seconds
+             , sum(s.shared_blk_write_time) / 1000 AS blk_write_time_seconds
         FROM pg_stat_statements s
         JOIN pg_database d ON s.dbid = d.oid
+        WHERE d.datname = current_database()
         GROUP BY d.datname;
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements';"


### PR DESCRIPTION
## Summary

- restore the PostgreSQL 17+ `shared_blk_read_time` and `shared_blk_write_time` columns from #248 after the dev-to-main squash dropped them
- restrict each wildcard database collection to `current_database()` to prevent duplicate Prometheus series
- retain the explicit PostgreSQL 17+ compatibility note

## Context

PR #248 was merged, but its commit was lost when `dev` and `main` were force-updated to the squashed release commit. As a result, chart versions 0.18.9 and 0.18.10 still packaged the pre-PostgreSQL-17 query and caused `CNPGInstanceMetricsFailing`.

## Validation

- `helm lint charts/paradedb`
- rendered the chart with pg_stat_statements instrumentation enabled and confirmed the `shared_blk_*` columns and `current_database()` filter
- `git diff --check`