### PR TITLE
feat(paradedb): improve index telemetry

### DIFF
--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5255,142 +5255,23 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "Current metadata and document statistics for each ParadeDB index, read from the current primary.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "filterable": false,
+            "inspect": false
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 48
-      },
-      "id": 807,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "mean",
-            "max"
+          "mappings": [
+
           ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "editorMode": "code",
-          "expr": "max by (relname) (cnpg_paradedb_index_segments_count * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
-          "legendFormat": "{{relname}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Segment count",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -5402,45 +5283,155 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #DELETED_RATIO"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #RELATION_SIZE"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 16,
+        "x": 0,
         "y": 48
       },
-      "id": 808,
+      "id": 807,
       "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "mean",
-            "max"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
+          "show": false
         },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
+        "showHeader": true,
+        "sortBy": [
+
+        ]
       },
       "pluginVersion": "11.5.1",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (relname) (cnpg_paradedb_index_total_docs * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
-          "legendFormat": "{{relname}}",
-          "range": true,
-          "refId": "A"
+          "expr": "max by (schema, tablename, relname) (cnpg_paradedb_index_total_docs{namespace=\"$namespace\"} * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "TOTAL_DOCS"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max by (schema, tablename, relname) (cnpg_paradedb_index_segments_count{namespace=\"$namespace\"} * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "SEGMENTS"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max by (schema, tablename, relname) (cnpg_paradedb_index_deleted_docs{namespace=\"$namespace\"} * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "DELETED_DOCS"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max by (schema, tablename, relname) (cnpg_paradedb_index_deleted_ratio{namespace=\"$namespace\"} * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "DELETED_RATIO"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max by (schema, tablename, relname) (cnpg_paradedb_index_relation_size{namespace=\"$namespace\"} * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "RELATION_SIZE"
         }
       ],
-      "title": "Total documents",
-      "type": "timeseries"
+      "title": "Index overview",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "cluster": true,
+              "container": true,
+              "customer": true,
+              "datname": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "prometheus": true,
+              "service": true
+            },
+            "includeByName": {
+            },
+            "indexByName": {
+              "schema": 0,
+              "tablename": 1,
+              "relname": 2,
+              "Value #TOTAL_DOCS": 3,
+              "Value #SEGMENTS": 4,
+              "Value #DELETED_DOCS": 5,
+              "Value #DELETED_RATIO": 6,
+              "Value #RELATION_SIZE": 7
+            },
+            "renameByName": {
+              "schema": "Schema",
+              "tablename": "Table",
+              "relname": "Index",
+              "Value #TOTAL_DOCS": "Total docs",
+              "Value #SEGMENTS": "Segments",
+              "Value #DELETED_DOCS": "Deleted docs",
+              "Value #DELETED_RATIO": "Deleted %",
+              "Value #RELATION_SIZE": "Relation size"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
+
     {
       "datasource": {
         "type": "prometheus",

--- a/charts/paradedb/monitoring/paradedb-dashboard.json
+++ b/charts/paradedb/monitoring/paradedb-dashboard.json
@@ -5400,7 +5400,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -5432,25 +5432,13 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "max by (relname) (cnpg_paradedb_index_segments_max_size * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
-          "legendFormat": "max {{relname}}",
+          "expr": "max by (relname) (cnpg_paradedb_index_total_docs * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
+          "legendFormat": "{{relname}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "max by (relname) (cnpg_paradedb_index_segments_avg_size * on (pod) group_left() (label_replace(kube_customresource_primary_info{customresource_group=\"postgresql.cnpg.io\", customresource_kind=\"Cluster\", namespace=\"$namespace\"}, \"pod\", \"$1\", \"current_primary\", \"(.*)\")))",
-          "hide": false,
-          "legendFormat": "avg {{relname}}",
-          "range": true,
-          "refId": "B"
         }
       ],
-      "title": "Segment size",
+      "title": "Total documents",
       "type": "timeseries"
     },
     {
@@ -5559,16 +5547,28 @@
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
         },
         "overrides": []
       },
@@ -5582,39 +5582,17 @@
       "maxDataPoints": 80,
       "maxPerRow": 2,
       "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "RdYlBu",
-          "steps": 64
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-9
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "multi",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "bytes"
-        }
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "11.5.1",
       "repeat": "paradedb_indexes",
@@ -5622,15 +5600,48 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\",relname=~\"$paradedb_indexes\"}) by (le)",
-          "format": "heatmap",
-          "legendFormat": "{{relname}}",
-          "range": true,
+          "expr": "max by (document_range, range_order) (cnpg_paradedb_index_document_distribution_segment_count{namespace=\"$namespace\",relname=~\"$paradedb_indexes\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "$paradedb_indexes segments",
-      "type": "heatmap"
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "range_order"
+              }
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "range_order": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "document_range": 0,
+              "Value": 1
+            },
+            "renameByName": {
+              "document_range": "Documents per segment",
+              "Value": "Segments"
+            }
+          }
+        }
+      ],
+      "type": "table",
+      "description": "Current distribution of segments by live-document count. Each row shows how many segments fall in that document-count range."
     },
     {
       "collapsed": false,
@@ -12043,14 +12054,14 @@
           "text": "All",
           "value": "$__all"
         },
-        "definition": "label_values(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\"},relname)",
+        "definition": "label_values(cnpg_paradedb_index_document_distribution_segment_count{namespace=\"$namespace\"},relname)",
         "hide": 2,
         "includeAll": true,
         "name": "paradedb_indexes",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(cnpg_paradedb_index_layer_segments_bucket{namespace=\"$namespace\"},relname)",
+          "query": "label_values(cnpg_paradedb_index_document_distribution_segment_count{namespace=\"$namespace\"},relname)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/charts/paradedb/templates/monitoring-paradedb-index.yaml
+++ b/charts/paradedb/templates/monitoring-paradedb-index.yaml
@@ -13,11 +13,23 @@ data:
       query: |
         SELECT current_database() as datname
              , i.schemaname AS schema
+             , i.tablename
              , i.indexname AS relname
              , pg_relation_size(i.indexrelid) AS relation_size
              , i.num_segments AS segments_count
              , i.total_docs
-        FROM pdb.indexes() i;
+             , COALESCE(s.deleted_docs, 0) AS deleted_docs
+             , COALESCE(s.max_docs, 0) AS max_docs
+             , CASE
+                 WHEN COALESCE(s.max_docs, 0) = 0 THEN 0::double precision
+                 ELSE s.deleted_docs::double precision / s.max_docs
+               END AS deleted_ratio
+        FROM pdb.indexes() i
+        LEFT JOIN LATERAL (
+          SELECT SUM(num_deleted)::bigint AS deleted_docs
+               , SUM(max_doc)::bigint AS max_docs
+          FROM pdb.index_segments(i.indexrelid)
+        ) s ON true;
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '{{ .Values.version.paradedb }}';"
       metrics:
@@ -26,6 +38,9 @@ data:
             usage: LABEL
         - schema:
             description: Schema within the database
+            usage: LABEL
+        - tablename:
+            description: Table the index is on
             usage: LABEL
         - relname:
             description: Index name
@@ -38,6 +53,15 @@ data:
             usage: GAUGE
         - total_docs:
             description: Total live documents across all segments
+            usage: GAUGE
+        - deleted_docs:
+            description: Total deleted documents across all segments
+            usage: GAUGE
+        - max_docs:
+            description: Total allocated document slots across all segments
+            usage: GAUGE
+        - deleted_ratio:
+            description: Fraction of allocated document slots that are deleted
             usage: GAUGE
     paradedb_index_document_distribution:
       query: |

--- a/charts/paradedb/templates/monitoring-paradedb-index.yaml
+++ b/charts/paradedb/templates/monitoring-paradedb-index.yaml
@@ -12,21 +12,12 @@ data:
     paradedb_index:
       query: |
         SELECT current_database() as datname
-             , n.nspname AS schema
-             , c.relname AS relname
-             , pg_relation_size(c.oid) AS relation_size
-             , COUNT(info.byte_size) AS segments_count
-             , MIN(info.byte_size) AS segments_min_size
-             , MAX(info.byte_size) AS segments_max_size
-             , AVG(info.byte_size) AS segments_avg_size
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        JOIN pg_index i ON i.indexrelid = c.oid
-        JOIN pg_am am ON am.oid = c.relam
-        JOIN LATERAL paradedb.index_info(c.oid) AS info ON true
-        WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-          AND am.amname = 'bm25'
-        GROUP BY n.nspname, c.relname, c.oid;
+             , i.schemaname AS schema
+             , i.indexname AS relname
+             , pg_relation_size(i.indexrelid) AS relation_size
+             , i.num_segments AS segments_count
+             , i.total_docs
+        FROM pdb.indexes() i;
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '{{ .Values.version.paradedb }}';"
       metrics:
@@ -45,45 +36,49 @@ data:
         - segments_count:
             description: Segment count
             usage: GAUGE
-        - segments_min_size:
-            description: Minimum segment size in bytes
+        - total_docs:
+            description: Total live documents across all segments
             usage: GAUGE
-        - segments_max_size:
-            description: Maximum segment size in bytes
-            usage: GAUGE
-        - segments_avg_size:
-            description: Average segment size in bytes
-            usage: GAUGE
-    paradedb_index_layer:
+    paradedb_index_document_distribution:
       query: |
-        WITH index_layer_histogram AS (
-          SELECT t.relname
-               , t.high
-               , SUM(i.count) AS count
-          FROM paradedb.index_layer_info t
-          LEFT JOIN paradedb.index_layer_info i
-          ON i.relname = t.relname AND i.high <= t.high
-          GROUP BY t.relname, t.high, t.relname
+        WITH buckets(range_order, document_range, min_docs, max_docs) AS (
+          VALUES (1, '<= 100K docs', NULL::bigint, 100000::bigint)
+               , (2, '100K-1M docs', 100000::bigint, 1000000::bigint)
+               , (3, '1M-10M docs', 1000000::bigint, 10000000::bigint)
+               , (4, '> 10M docs', 10000000::bigint, NULL::bigint)
         )
         SELECT current_database() as datname
-             , t.relname
-             , SUM(t.byte_size)   AS segments_sum
-             , SUM(t.count)       AS segments_count
-             , ARRAY_AGG(t.high)  AS segments
-             , ARRAY_AGG(i.count) AS segments_bucket
-        FROM paradedb.index_layer_info t
-        LEFT JOIN index_layer_histogram i ON i.relname = t.relname AND i.high = t.high
-        GROUP BY datname, t.relname;
+             , i.schemaname AS schema
+             , i.indexname AS relname
+             , b.range_order::text
+             , b.document_range
+             , COUNT(s.segment_idx) AS segment_count
+        FROM pdb.indexes() i
+        CROSS JOIN buckets b
+        LEFT JOIN LATERAL pdb.index_segments(i.indexrelid) s
+          ON (b.min_docs IS NULL OR s.num_docs > b.min_docs)
+         AND (b.max_docs IS NULL OR s.num_docs <= b.max_docs)
+        GROUP BY current_database(), i.schemaname, i.indexname, b.range_order, b.document_range
+        ORDER BY i.schemaname, i.indexname, b.range_order;
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '{{ .Values.version.paradedb }}';"
       metrics:
         - datname:
             description: Name of the database
             usage: LABEL
+        - schema:
+            description: Schema within the database
+            usage: LABEL
         - relname:
             description: Index name
             usage: LABEL
-        - segments:
-            description: Layer segments size distribution
-            usage: HISTOGRAM
+        - range_order:
+            description: Numeric display order for the document-count range
+            usage: LABEL
+        - document_range:
+            description: Number of live documents in each segment
+            usage: LABEL
+        - segment_count:
+            description: Number of segments in the document-count range
+            usage: GAUGE
 {{- end }}

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -78,19 +78,14 @@ spec:
             curl -sk $POD_URL | grep paradedb_index_relation_size
             echo "paradedb_index_segments_count"
             curl -sk $POD_URL | grep paradedb_index_segments_count
-            echo "paradedb_index_segments_min_size"
-            curl -sk $POD_URL | grep paradedb_index_segments_min_size
-            echo "paradedb_index_segments_max_size"
-            curl -sk $POD_URL | grep paradedb_index_segments_max_size
-            echo "paradedb_index_segments_avg_size"
-            curl -sk $POD_URL | grep paradedb_index_segments_avg_size
+            echo "paradedb_index_total_docs"
+            curl -sk $POD_URL | grep paradedb_index_total_docs
 
-            echo "paradedb_index_layer_segments_bucket"
-            curl -sk $POD_URL | grep paradedb_index_layer_segments_bucket
-            echo "paradedb_index_layer_segments_count"
-            curl -sk $POD_URL | grep paradedb_index_layer_segments_count
-            echo "paradedb_index_layer_segments_sum"
-            curl -sk $POD_URL | grep paradedb_index_layer_segments_sum
+            echo "paradedb_index_document_distribution_segment_count"
+            curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="<= 100K docs"'
+            curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="100K-1M docs"'
+            curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="1M-10M docs"'
+            curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="> 10M docs"'
 
             echo "pg_stat_activity_long_running_avg_duration"
             curl -sk $POD_URL | grep pg_stat_activity_long_running_avg_duration

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -80,6 +80,12 @@ spec:
             curl -sk $POD_URL | grep paradedb_index_segments_count
             echo "paradedb_index_total_docs"
             curl -sk $POD_URL | grep paradedb_index_total_docs
+            echo "paradedb_index_deleted_docs"
+            curl -sk $POD_URL | grep paradedb_index_deleted_docs
+            echo "paradedb_index_max_docs"
+            curl -sk $POD_URL | grep paradedb_index_max_docs
+            echo "paradedb_index_deleted_ratio"
+            curl -sk $POD_URL | grep paradedb_index_deleted_ratio
 
             echo "paradedb_index_document_distribution_segment_count"
             curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="<= 100K docs"'


### PR DESCRIPTION
## What

- migrate index monitoring from legacy `paradedb.index_info` and `paradedb.index_layer_info` to supported `pdb.indexes()` and `pdb.index_segments()` APIs
- export stable per-index metadata and gauges: schema, table, index name, relation size, segment count, total live documents, deleted documents, allocated document slots, and deletion ratio
- export segment counts in four live-document ranges: `<= 100K`, `100K-1M`, `1M-10M`, and `> 10M`
- replace the separate segment-count/total-document charts with an index-overview table while retaining relation-size history
- replace the segment-size heatmap with a simple document-distribution table
- update monitoring integration assertions

Raw segment IDs, segment indices, and index OIDs are intentionally not exported because they are unstable and would create high-cardinality stale series as indexes merge or rebuild.

## Validation

- `helm lint charts/paradedb`
- rendered the chart with the Grafana dashboard and index instrumentation enabled
- dashboard JSON validation
- repository hooks for all changed files

## Related

- paradedb/cloud#788
- paradedb/mcc#257
- paradedb/mcc#178