### PR TITLE
feat(monitoring): export ParadeDB index health

### DIFF
--- a/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
+++ b/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The `ParadeDBIndexInvalid` alert is triggered when PostgreSQL reports that a ParadeDB BM25 index on the cluster primary is invalid or not ready for inserts.
+The `ParadeDBIndexInvalid` alert is triggered when PostgreSQL reports that a ParadeDB index on the cluster primary is invalid or not ready for inserts.
 
 This commonly happens when `CREATE INDEX CONCURRENTLY` fails or is cancelled. PostgreSQL leaves the incomplete index behind, but the planner will not use an invalid index. Search queries can silently fall back to a sequential scan and become much slower without returning an application error.
 
@@ -28,7 +28,7 @@ JOIN pg_namespace n ON n.oid = c.relnamespace
 JOIN pg_index i ON i.indexrelid = c.oid
 JOIN pg_class t ON t.oid = i.indrelid
 JOIN pg_am am ON am.oid = c.relam
-WHERE am.amname = 'bm25'
+WHERE am.amname = 'paradedb'
   AND (NOT i.indisvalid OR NOT i.indisready)
 ORDER BY n.nspname, c.relname;
 "
@@ -44,7 +44,7 @@ PostgreSQL cannot make a failed concurrent index valid after the fact. Drop the 
 DROP INDEX CONCURRENTLY <schema>.<index_name>;
 CREATE INDEX CONCURRENTLY <index_name>
 ON <schema>.<table_name>
-USING bm25 (...)
+USING paradedb (...)
 WITH (key_field = '<key_column>');
 ```
 

--- a/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
+++ b/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
@@ -1,0 +1,53 @@
+# ParadeDBIndexInvalid
+
+## Description
+
+The `ParadeDBIndexInvalid` alert is triggered when PostgreSQL reports that a ParadeDB BM25 index on the cluster primary is invalid or not ready for inserts.
+
+This commonly happens when `CREATE INDEX CONCURRENTLY` fails or is cancelled. PostgreSQL leaves the incomplete index behind, but the planner will not use an invalid index. Search queries can silently fall back to a sequential scan and become much slower without returning an application error.
+
+## Impact
+
+- An index with `indisvalid = false` is not available to the query planner.
+- An index with `indisready = false` does not receive inserts and can fall behind its table.
+- Queries that normally use the index may consume substantially more CPU and take much longer.
+
+## Diagnosis
+
+Inspect the index state on the primary:
+
+```bash
+kubectl exec -n <namespace> -it services/paradedb-rw -- psql -c "
+SELECT n.nspname AS schema,
+       t.relname AS table_name,
+       c.relname AS index_name,
+       i.indisvalid,
+       i.indisready
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_index i ON i.indexrelid = c.oid
+JOIN pg_class t ON t.oid = i.indrelid
+JOIN pg_am am ON am.oid = c.relam
+WHERE am.amname = 'bm25'
+  AND (NOT i.indisvalid OR NOT i.indisready)
+ORDER BY n.nspname, c.relname;
+"
+```
+
+Check PostgreSQL logs and recent deployment or maintenance activity to determine why the index build failed. Confirm that another index build is not still in progress before changing the index.
+
+## Mitigation
+
+PostgreSQL cannot make a failed concurrent index valid after the fact. Drop the invalid index and recreate it:
+
+```sql
+DROP INDEX CONCURRENTLY <schema>.<index_name>;
+CREATE INDEX CONCURRENTLY <index_name>
+ON <schema>.<table_name>
+USING bm25 (...)
+WITH (key_field = '<key_column>');
+```
+
+Recover the exact original definition with `pg_get_indexdef(indexrelid)` before dropping the index. Schedule the rebuild with enough time and capacity to finish, and do not cancel it unless leaving another invalid index is acceptable.
+
+After recreation, confirm both `indisvalid` and `indisready` are true and that the alert clears.

--- a/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
+++ b/charts/paradedb/docs/runbooks/ParadeDBIndexInvalid.md
@@ -4,12 +4,13 @@
 
 The `ParadeDBIndexInvalid` alert is triggered when PostgreSQL reports that a ParadeDB index on the cluster primary is invalid or not ready for inserts.
 
-This commonly happens when `CREATE INDEX CONCURRENTLY` fails or is cancelled. PostgreSQL leaves the incomplete index behind, but the planner will not use an invalid index. Search queries can silently fall back to a sequential scan and become much slower without returning an application error.
+This commonly happens when `CREATE INDEX CONCURRENTLY` fails or is cancelled. PostgreSQL leaves the incomplete index behind, consuming storage even though the planner will not use it. Search queries can silently fall back to a sequential scan and become much slower without returning an application error.
 
 ## Impact
 
 - An index with `indisvalid = false` is not available to the query planner.
 - An index with `indisready = false` does not receive inserts and can fall behind its table.
+- The incomplete index continues to occupy storage until it is dropped.
 - Queries that normally use the index may consume substantially more CPU and take much longer.
 
 ## Diagnosis

--- a/charts/paradedb/templates/monitoring-paradedb-index.yaml
+++ b/charts/paradedb/templates/monitoring-paradedb-index.yaml
@@ -63,6 +63,44 @@ data:
         - deleted_ratio:
             description: Fraction of allocated document slots that are deleted
             usage: GAUGE
+    # Keep health separate from pdb.indexes() and pdb.index_segments(). An invalid or
+    # incomplete index must still be observable even when ParadeDB cannot inspect it.
+    paradedb_index_health:
+      query: |
+        SELECT current_database() AS datname
+             , n.nspname AS schema
+             , t.relname AS tablename
+             , c.relname AS relname
+             , i.indisvalid::int AS is_valid
+             , i.indisready::int AS is_ready
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        JOIN pg_class t ON t.oid = i.indrelid
+        JOIN pg_am am ON am.oid = c.relam
+        WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+          AND am.amname = 'bm25';
+      target_databases: ["*"]
+      predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '{{ .Values.version.paradedb }}';"
+      metrics:
+        - datname:
+            description: Name of the database
+            usage: LABEL
+        - schema:
+            description: Schema within the database
+            usage: LABEL
+        - tablename:
+            description: Table the index is on
+            usage: LABEL
+        - relname:
+            description: Index name
+            usage: LABEL
+        - is_valid:
+            description: Whether the index is valid for queries
+            usage: GAUGE
+        - is_ready:
+            description: Whether the index is ready for inserts
+            usage: GAUGE
     paradedb_index_document_distribution:
       query: |
         WITH buckets(range_order, document_range, min_docs, max_docs) AS (

--- a/charts/paradedb/templates/monitoring-paradedb-index.yaml
+++ b/charts/paradedb/templates/monitoring-paradedb-index.yaml
@@ -79,7 +79,7 @@ data:
         JOIN pg_class t ON t.oid = i.indrelid
         JOIN pg_am am ON am.oid = c.relam
         WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
-          AND am.amname = 'bm25';
+          AND am.amname = 'paradedb';
       target_databases: ["*"]
       predicate_query: "SELECT 1 FROM pg_extension WHERE extname = 'pg_search' AND extversion = '{{ .Values.version.paradedb }}';"
       metrics:

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -86,6 +86,10 @@ spec:
             curl -sk $POD_URL | grep paradedb_index_max_docs
             echo "paradedb_index_deleted_ratio"
             curl -sk $POD_URL | grep paradedb_index_deleted_ratio
+            echo "paradedb_index_health_is_valid"
+            curl -sk $POD_URL | grep paradedb_index_health_is_valid
+            echo "paradedb_index_health_is_ready"
+            curl -sk $POD_URL | grep paradedb_index_health_is_ready
 
             echo "paradedb_index_document_distribution_segment_count"
             curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="<= 100K docs"'


### PR DESCRIPTION
Closes paradedb/mcc#244 (charts portion).

Adds a catalog-only CNPG custom query for ParadeDB index validity/readiness, verifies both exported metrics in the monitoring test, and adds the runbook consumed by the MCC alert. Keeping the health query separate from ParadeDB index inspection ensures an invalid index cannot suppress its own health signal.

Validation: `helm lint charts/paradedb`; rendered the monitoring ConfigMap with ParadeDB index instrumentation enabled.