### PR TITLE
fix: use ParadeDB index access method

### DIFF
--- a/charts/paradedb/docs/long-running-tasks.md
+++ b/charts/paradedb/docs/long-running-tasks.md
@@ -29,7 +29,7 @@ We provide the database credentials as environment variables in the console pod.
 To run a command in the background you can use the `nohup` command. For example, to create an index in the background:
 
 ```bash
-nohup psql "$DB_SUPERUSER_URI/<db-name>" -c "CREATE INDEX orders_idx ON orders USING bm25 (order_id, customer_name) WITH (key_field='order_id');" 2>&1 > command.log &
+nohup psql "$DB_SUPERUSER_URI/<db-name>" -c "CREATE INDEX orders_idx ON orders USING paradedb (order_id, customer_name) WITH (key_field='order_id');" 2>&1 > command.log &
 ```
 
 To check on the status of the command, you can use the `tail` command:

--- a/charts/paradedb/test/monitoring/02-paradedb.yaml
+++ b/charts/paradedb/test/monitoring/02-paradedb.yaml
@@ -21,4 +21,4 @@ spec:
             apk --no-cache add postgresql-client
             set -e
             psql $DB_URI -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
-            psql $DB_URI -c "CREATE INDEX search_idx ON mock_items USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
+            psql $DB_URI -c "CREATE INDEX search_idx ON mock_items USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"

--- a/charts/paradedb/test/paradedb-enterprise/02-paradedb_test.yaml
+++ b/charts/paradedb/test/paradedb-enterprise/02-paradedb_test.yaml
@@ -25,7 +25,7 @@ spec:
                 table_name => 'mock_items_paradedb_enterprise'
               );
               CREATE INDEX search_idx_paradedb_enterprise ON mock_items_paradedb_enterprise
-              USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+              USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
               WITH (key_field='id');
             EOSQL
             RESULT=$(psql "$DB_URI" -t) <<-EOSQL

--- a/charts/paradedb/test/paradedb-minio-backup-restore/02-paradedb_write.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/02-paradedb_write.yaml
@@ -25,6 +25,6 @@ spec:
                 table_name => 'mock_items_paradedb_minio_backup_restore'
               );
               CREATE INDEX search_idx_paradedb_minio_backup_restore ON mock_items_paradedb_minio_backup_restore
-              USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+              USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
               WITH (key_field='id');
             EOSQL

--- a/charts/paradedb/test/replica/02-data_write.yaml
+++ b/charts/paradedb/test/replica/02-data_write.yaml
@@ -35,7 +35,7 @@ spec:
                table_name => 'mock_items_paradedb_enterprise'
              );
              CREATE INDEX search_idx_paradedb_enterprise ON mock_items_paradedb_enterprise
-             USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range)
+             USING paradedb (id, description, category, rating, in_stock, created_at, metadata, weight_range)
              WITH (key_field='id');
            EOSQL
            RESULT=$(psql "$DB_URI/paradedb" -t) <<-EOSQL


### PR DESCRIPTION
Updates current chart documentation and integration fixtures from the deprecated `USING bm25` alias to `USING paradedb`.

Historical and compatibility references are not changed.

Validation: `helm lint charts/paradedb`.