### PR TITLE
feat(monitoring): export ParadeDB version match

### DIFF
--- a/charts/paradedb/docs/runbooks/ParadeDBVersionMismatch.md
+++ b/charts/paradedb/docs/runbooks/ParadeDBVersionMismatch.md
@@ -1,0 +1,47 @@
+# ParadeDBVersionMismatch
+
+## Description
+
+The `ParadeDBVersionMismatch` alert fires when the `pg_search` extension version recorded in PostgreSQL does not match the ParadeDB version declared by the Helm release for at least 15 minutes.
+
+ParadeDB loads native code into PostgreSQL. If the extension catalog and the installed binary disagree, calls into `pg_search` can cause errors. ParadeDB monitoring queries that use extension functions are therefore disabled until the versions match, leaving index health and telemetry unavailable.
+
+## Impact
+
+- Queries that invoke `pg_search` can return errors.
+- ParadeDB index health, size, segment, and document metrics stop being collected intentionally.
+- Search traffic may fail or be disrupted until the catalog and binary versions agree.
+
+## Diagnosis
+
+Compare the version in the loaded ParadeDB binary with the version recorded in PostgreSQL's extension catalog:
+
+```sql
+SELECT * FROM paradedb.version_info();
+SELECT extversion FROM pg_extension WHERE extname = 'pg_search';
+```
+
+`paradedb.version_info()` reports the version in the installed binary, while `pg_extension.extversion` reports the version PostgreSQL's catalog expects. If they do not match, binary/catalog version skew is causing the alert.
+
+The most common cause is upgrading the ParadeDB binary without subsequently running `ALTER EXTENSION pg_search UPDATE` in the database, leaving PostgreSQL's extension catalog and SQL objects on the older version.
+
+Also compare both values with the alert's `expected_version` label and the version configured in the Helm release. Inspect the images CloudNativePG is running:
+
+```bash
+kubectl get pods -n <namespace> -l cnpg.io/cluster=<cluster> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[?(@.name=="postgres")].image}{"\n"}{end}'
+```
+
+## Mitigation
+
+If `paradedb.version_info()` reports the intended binary version but `pg_extension.extversion` is older, update the extension in every database where `pg_search` is installed:
+
+```sql
+ALTER EXTENSION pg_search UPDATE TO '<binary_version>';
+```
+
+If `pg_extension.extversion` is newer than `paradedb.version_info()`, the binary upgrade has not completed. Reconcile the deployed image and restart PostgreSQL rather than altering the catalog backward.
+
+Ensure `version.paradedb`, the deployed ParadeDB image, and the managed `pg_search` extension version all refer to the same release. If `cluster.imageName` or `cluster.imageCatalogRef` overrides the default image, verify that the override contains the version declared by `version.paradedb`.
+
+Allow CloudNativePG to complete any rolling restart and extension reconciliation. Then rerun both diagnosis queries, confirm their versions match, and verify that every database reports `cnpg_paradedb_version_match` as `1`.

--- a/charts/paradedb/templates/monitoring-paradedb-index.yaml
+++ b/charts/paradedb/templates/monitoring-paradedb-index.yaml
@@ -9,6 +9,30 @@ metadata:
     {{- include "cluster.labels" . | nindent 4 }}
 data:
   custom-queries: |
+    # This query must remain catalog-only. Calling into pg_search while its SQL
+    # catalog and loaded binary disagree can cause errors.
+    paradedb_version:
+      query: |
+        SELECT current_database() AS datname
+             , extversion AS installed_version
+             , '{{ .Values.version.paradedb }}'::text AS expected_version
+             , (extversion = '{{ .Values.version.paradedb }}')::int AS "match"
+        FROM pg_extension
+        WHERE extname = 'pg_search';
+      target_databases: ["*"]
+      metrics:
+        - datname:
+            description: Name of the database
+            usage: LABEL
+        - installed_version:
+            description: Version recorded in the pg_search extension catalog
+            usage: LABEL
+        - expected_version:
+            description: ParadeDB version declared by the Helm release
+            usage: LABEL
+        - match:
+            description: Whether the pg_search extension catalog matches the declared ParadeDB version
+            usage: GAUGE
     paradedb_index:
       query: |
         SELECT current_database() as datname

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -90,6 +90,10 @@ spec:
             curl -sk $POD_URL | grep paradedb_index_health_is_valid
             echo "paradedb_index_health_is_ready"
             curl -sk $POD_URL | grep paradedb_index_health_is_ready
+            echo "paradedb_version_match"
+            # CI replaces version.paradedb with the latest release candidate, so
+            # assert the healthy gauge without hard-coding a particular version.
+            curl -sk $POD_URL | grep 'cnpg_paradedb_version_match{.*} 1$'
 
             echo "paradedb_index_document_distribution_segment_count"
             curl -sk $POD_URL | grep 'paradedb_index_document_distribution_segment_count.*document_range="<= 100K docs"'

--- a/charts/paradedb/test/monitoring/03-metrics-test.yaml
+++ b/charts/paradedb/test/monitoring/03-metrics-test.yaml
@@ -91,8 +91,6 @@ spec:
             echo "paradedb_index_health_is_ready"
             curl -sk $POD_URL | grep paradedb_index_health_is_ready
             echo "paradedb_version_match"
-            # CI replaces version.paradedb with the latest release candidate, so
-            # assert the healthy gauge without hard-coding a particular version.
             curl -sk $POD_URL | grep 'cnpg_paradedb_version_match{.*} 1$'
 
             echo "paradedb_index_document_distribution_segment_count"


### PR DESCRIPTION
## What

- export `cnpg_paradedb_version_match` from a catalog-only query
- label the metric with the installed and expected versions
- keep all UDF-backed index metrics behind their exact-version predicates
- add a runbook and exercise the metric in the monitoring integration test

## Why

A pg_search binary/catalog mismatch can crash PostgreSQL backends if monitoring calls into extension UDFs. The existing predicates correctly suppress those calls, but that makes index telemetry disappear silently. This safe metric exposes the underlying version skew directly.

For the standard chart deployment, `version.paradedb` determines both the image tag and managed extension version. Custom images and image catalogs must continue to match that declared version.

## Verification

- `helm lint charts/paradedb`
- `helm template monitoring charts/paradedb --values charts/paradedb/test/monitoring/01-monitoring_cluster.yaml --namespace test`
- targeted pre-commit hooks

Supports paradedb/mcc#246.