### PR TITLE
feat(monitoring): alert on replication slot retention

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGReplicationSlotRetention.md
+++ b/charts/paradedb/docs/runbooks/CNPGReplicationSlotRetention.md
@@ -1,0 +1,48 @@
+# CNPGReplicationSlotRetention
+
+## Description
+
+The `CNPGReplicationSlotInactive` alert fires when a replication slot on the primary has been inactive while retaining WAL for at least 15 minutes. The `CNPGReplicationSlotHighRetention` alert fires when a slot retains more than 25% of the volume that stores WAL for at least 15 minutes.
+
+PostgreSQL retains every WAL segment required by a replication slot until its consumer advances the slot. An abandoned logical subscriber or a disconnected physical replica can therefore fill the volume indefinitely, at which point PostgreSQL stops accepting writes.
+
+## Impact
+
+- WAL storage grows until the affected consumer reconnects, advances, or the slot is removed.
+- Backups and healthy replicas do not release WAL retained for another slot.
+- If the volume fills, PostgreSQL can no longer accept writes and may become unavailable.
+
+## Diagnosis
+
+Inspect non-temporary slots on the primary:
+
+```sql
+SELECT slot_name,
+       slot_type,
+       database,
+       active,
+       active_pid,
+       restart_lsn,
+       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+FROM pg_replication_slots
+WHERE NOT temporary
+ORDER BY pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) DESC NULLS LAST;
+```
+
+For a logical slot, identify the subscription or external CDC consumer that owns `slot_name`. For a physical slot whose name begins with `_cnpg_`, inspect the corresponding CloudNativePG replica and its WAL receiver. Check recent consumer, network, and PostgreSQL logs before deciding that a slot is abandoned.
+
+Confirm whether the cluster has dedicated WAL storage. A PVC ending in `-wal` stores retained WAL when present; otherwise WAL shares the instance's data PVC.
+
+## Mitigation
+
+Restore the intended consumer first. Once it reconnects and advances its confirmed or replay LSN, PostgreSQL will recycle the retained WAL automatically.
+
+If a logical consumer has been permanently removed, verify that it cannot return and that its retained changes are no longer required, then drop its slot on the primary:
+
+```sql
+SELECT pg_drop_replication_slot('<slot_name>');
+```
+
+Dropping a slot is irreversible and forces that consumer to be reinitialized from a new snapshot or base backup. Do not manually drop CloudNativePG-managed `_cnpg_` physical slots; repair or remove the corresponding replica through CloudNativePG instead.
+
+If the volume is close to full, add storage before recovery work so the database does not run out of space while the consumer catches up. Confirm afterward that the slot is active or gone, retained bytes are falling, and both alerts clear.

--- a/charts/paradedb/prometheus_rules/cluster-replication_slot_high_retention-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-replication_slot_high_retention-warning.yaml
@@ -1,0 +1,39 @@
+{{- $alert := "CNPGReplicationSlotHighRetention" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: PostgreSQL replication slot is retaining too much WAL
+  description: |-
+    Replication slot "{{ .labels.slot_name }}" ({{ .labels.slot_type }}) on primary
+    "{{ .namespace }}/{{ .cluster }}/{{ .labels.pod }}" is retaining
+    {{ .valuePercent }} of volume "{{ .labels.persistentvolumeclaim }}".
+
+    A stalled or badly lagging consumer can retain WAL indefinitely. At the current level, this
+    slot is a material risk to the volume and can eventually fill it and stop writes.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGReplicationSlotRetention.md
+expr: |
+  max by (namespace, pod, slot_name, slot_type, persistentvolumeclaim) (
+    (
+      cnpg_pg_replication_slots_pg_wal_lsn_diff{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+      and on (namespace, pod)
+        (cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 0)
+    )
+    / on (namespace, pod) group_left(persistentvolumeclaim)
+    (
+      label_replace(
+        kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}",persistentvolumeclaim=~"{{ .pvcSelector }}-wal"},
+        "pod", "$1", "persistentvolumeclaim", "(.+)-wal"
+      )
+      or on (namespace, pod)
+      label_replace(
+        kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}",persistentvolumeclaim=~"{{ .pvcSelector }}"},
+        "pod", "$1", "persistentvolumeclaim", "(.+)"
+      )
+    )
+  ) > 0.25
+for: 15m
+labels:
+  severity: warning
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/prometheus_rules/cluster-replication_slot_inactive-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-replication_slot_inactive-warning.yaml
@@ -1,0 +1,27 @@
+{{- $alert := "CNPGReplicationSlotInactive" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: PostgreSQL replication slot is inactive and retaining WAL
+  description: |-
+    Replication slot "{{ .labels.slot_name }}" ({{ .labels.slot_type }}) on primary
+    "{{ .namespace }}/{{ .cluster }}/{{ .labels.pod }}" is inactive and retaining
+    {{ .value }} bytes of WAL.
+
+    PostgreSQL retains this WAL indefinitely while the slot cannot advance. If the consumer does
+    not recover or the abandoned slot is not removed, the WAL volume can fill and stop writes.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGReplicationSlotRetention.md
+expr: |
+  max by (namespace, pod, slot_name, slot_type) (
+    cnpg_pg_replication_slots_pg_wal_lsn_diff{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}
+    and on (namespace, pod, slot_name, slot_type)
+      (cnpg_pg_replication_slots_active{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 0)
+    and on (namespace, pod)
+      (cnpg_pg_replication_in_recovery{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"} == 0)
+  ) > 0
+for: 15m
+labels:
+  severity: warning
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/templates/prometheus-rule.yaml
+++ b/charts/paradedb/templates/prometheus-rule.yaml
@@ -18,8 +18,9 @@ spec:
         {{- $_ := set $dict "valuePercent" "{{ $value | humanizePercentage }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
-        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}") -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}") -}}
         {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
+        {{- $_ := set $dict "pvcSelector" (printf "%s-([1-9][0-9]*)" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "Values"      .Values -}}
         {{- $_ := set $dict "Template"    .Template -}}
         {{- range $path, $_ := .Files.Glob  "prometheus_rules/**.yaml" }}

--- a/charts/paradedb/test/replica/04-replica_cluster_enterprise.yaml
+++ b/charts/paradedb/test/replica/04-replica_cluster_enterprise.yaml
@@ -1,5 +1,8 @@
 type: paradedb-enterprise
 mode: replica
+version:
+  major: "18"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/replication-slot-alert-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/replication-slot-alert-rendering/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: replication-slot-alert-rendering
+spec:
+  steps:
+    - name: Render replication slot alerts
+      try:
+        - script:
+            content: |
+              set -eu
+
+              render() {
+                helm template slot-alerts ../../ \
+                  --namespace slot-test \
+                  --set cluster.monitoring.enabled=true \
+                  --set cluster.monitoring.prometheusRule.enabled=true \
+                  "$@" \
+                  --show-only templates/prometheus-rule.yaml
+              }
+
+              rendered="$(render)"
+              printf '%s\n' "$rendered" | grep -q 'alert: CNPGReplicationSlotInactive'
+              printf '%s\n' "$rendered" | grep -q 'alert: CNPGReplicationSlotHighRetention'
+              printf '%s\n' "$rendered" | grep -q 'persistentvolumeclaim=~"slot-alerts-paradedb-([1-9][0-9]*)-wal"'
+              printf '%s\n' "$rendered" | grep -q 'cnpg_pg_replication_in_recovery'
+
+              excluded="$(render \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[0]=CNPGReplicationSlotInactive' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention')"
+              if printf '%s\n' "$excluded" | grep -q 'CNPGReplicationSlot'; then
+                echo "excluded replication slot alerts must not render"
+                exit 1
+              fi

--- a/charts/paradedb/test/replication-slot-alert-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/replication-slot-alert-rendering/chainsaw-test.yaml
@@ -20,15 +20,15 @@ spec:
               }
 
               rendered="$(render)"
-              printf '%s\n' "$rendered" | grep -q 'alert: CNPGReplicationSlotInactive'
-              printf '%s\n' "$rendered" | grep -q 'alert: CNPGReplicationSlotHighRetention'
-              printf '%s\n' "$rendered" | grep -q 'persistentvolumeclaim=~"slot-alerts-paradedb-([1-9][0-9]*)-wal"'
-              printf '%s\n' "$rendered" | grep -q 'cnpg_pg_replication_in_recovery'
+              printf '%s\n' "$rendered" | grep -Fq 'alert: CNPGReplicationSlotInactive'
+              printf '%s\n' "$rendered" | grep -Fq 'alert: CNPGReplicationSlotHighRetention'
+              printf '%s\n' "$rendered" | grep -Fq 'persistentvolumeclaim=~"slot-alerts-paradedb-([1-9][0-9]*)-wal"'
+              printf '%s\n' "$rendered" | grep -Fq 'cnpg_pg_replication_in_recovery'
 
               excluded="$(render \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[0]=CNPGReplicationSlotInactive' \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention')"
-              if printf '%s\n' "$excluded" | grep -q 'CNPGReplicationSlot'; then
+              if printf '%s\n' "$excluded" | grep -Fq 'CNPGReplicationSlot'; then
                 echo "excluded replication slot alerts must not render"
                 exit 1
               fi


### PR DESCRIPTION
## What

- warn when a primary replication slot is inactive and retaining WAL for 15 minutes
- warn when any primary slot retains more than 25% of the volume that stores WAL
- prefer the dedicated `-wal` PVC when present and fall back to the data PVC
- filter standby slot observations with `cnpg_pg_replication_in_recovery`
- support both alerts through `excludeRules`
- add rendering coverage and the shared diagnosis/remediation runbook

## Why

An abandoned or lagging replication slot retains WAL indefinitely and can fill the volume until PostgreSQL stops accepting writes.

Supports paradedb/mcc#241.