### PR TITLE
feat(monitoring): alert when primary recovery is stuck

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGClusterPrimaryFailing.md
+++ b/charts/paradedb/docs/runbooks/CNPGClusterPrimaryFailing.md
@@ -1,0 +1,37 @@
+# CNPGClusterPrimaryFailing
+
+## Description
+
+The `CNPGClusterPrimaryFailing` alert fires when CloudNativePG has reported a failing primary for more than five minutes and the condition then remains active for another five minutes. A successful promotion or brief primary transition does not trigger the alert.
+
+## Impact
+
+- The cluster may not have a stable writable primary.
+- Applications can experience failed connections, interrupted transactions, or write unavailability.
+- Automatic failover or switchover recovery is not completing within the expected window.
+
+## Diagnosis
+
+Inspect the cluster status and conditions:
+
+```bash
+kubectl describe -n <namespace> cluster/<cluster-name>
+kubectl get -n <namespace> cluster/<cluster-name> -o yaml
+```
+
+Compare `status.currentPrimary` with `status.targetPrimary`, then inspect recent cluster events and operator logs:
+
+```bash
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+kubectl logs -n cnpg-system deployment/cnpg-controller-manager --since=30m
+```
+
+Check the current and target primary pods for restarts, scheduling failures, storage errors, failed probes, or PostgreSQL startup errors.
+
+## Mitigation
+
+Resolve the underlying pod, node, storage, networking, or PostgreSQL failure preventing CloudNativePG from completing recovery. Preserve the current cluster state and logs before deleting pods or changing the primary target.
+
+Do not manually promote a replica or modify CloudNativePG status fields. If the operator cannot recover after the underlying failure is corrected, follow the CloudNativePG failover procedures or escalate with the cluster status, events, and instance logs.
+
+Confirm afterward that `currentPrimary` and `targetPrimary` match, the failing timestamp is cleared, the write service accepts connections, and the alert resolves.

--- a/charts/paradedb/docs/runbooks/CNPGClusterPrimaryFailing.md
+++ b/charts/paradedb/docs/runbooks/CNPGClusterPrimaryFailing.md
@@ -26,12 +26,12 @@ kubectl get events -n <namespace> --sort-by=.lastTimestamp
 kubectl logs -n cnpg-system deployment/cnpg-controller-manager --since=30m
 ```
 
-Check the current and target primary pods for restarts, scheduling failures, storage errors, failed probes, or PostgreSQL startup errors.
+Check the current and target primary pods for restarts, scheduling failures, storage errors, failed probes, or PostgreSQL startup errors. A failover can also remain stuck when a long-running query on the current primary cannot be cancelled, preventing the operator from completing the transition.
 
 ## Mitigation
 
 Resolve the underlying pod, node, storage, networking, or PostgreSQL failure preventing CloudNativePG from completing recovery. Preserve the current cluster state and logs before deleting pods or changing the primary target.
 
-Do not manually promote a replica or modify CloudNativePG status fields. If the operator cannot recover after the underlying failure is corrected, follow the CloudNativePG failover procedures or escalate with the cluster status, events, and instance logs.
+Do not manually trigger another replica promotion or modify CloudNativePG status fields. A promotion is already in progress, and starting a second concurrent promotion can lead to data loss. If the operator cannot recover after the underlying failure is corrected, follow the CloudNativePG failover procedures or escalate with the cluster status, events, and instance logs.
 
 Confirm afterward that `currentPrimary` and `targetPrimary` match, the failing timestamp is cleared, the write service accepts connections, and the alert resolves.

--- a/charts/paradedb/prometheus_rules/cluster-primary_failing-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-primary_failing-critical.yaml
@@ -1,0 +1,34 @@
+{{- $alert := "CNPGClusterPrimaryFailing" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: CloudNativePG primary recovery is not completing
+  description: |-
+    Cluster "{{ .namespace }}/{{ .cluster }}" has reported a failing primary for more than
+    five minutes and has not recovered. Current primary: "{{ .labels.current_primary }}";
+    target primary: "{{ .labels.target_primary }}".
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGClusterPrimaryFailing.md
+expr: |
+  (
+    time() - max by (namespace, cluster, primary) (
+      kube_customresource_primary_failing_since_time{
+        customresource_group="postgresql.cnpg.io",
+        customresource_kind="Cluster",
+        namespace="{{ .namespace }}",
+        cluster="{{ .cluster }}"
+      }
+    ) > 300
+  )
+  * on (namespace, cluster) group_left(current_primary, target_primary)
+  kube_customresource_primary_info{
+    customresource_group="postgresql.cnpg.io",
+    customresource_kind="Cluster",
+    namespace="{{ .namespace }}",
+    cluster="{{ .cluster }}"
+  }
+for: 5m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/templates/prometheus-rule.yaml
+++ b/charts/paradedb/templates/prometheus-rule.yaml
@@ -19,7 +19,7 @@ spec:
         {{- $_ := set $dict "valuePercent" "{{ $value | humanizePercentage }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
-        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}" "datname" "{{ $labels.datname }}" "age_kind" "{{ $labels.age_kind }}") -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}" "datname" "{{ $labels.datname }}" "age_kind" "{{ $labels.age_kind }}" "current_primary" "{{ $labels.current_primary }}" "target_primary" "{{ $labels.target_primary }}") -}}
         {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "pvcSelector" (printf "%s-([1-9][0-9]*)" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "Values"      .Values -}}

--- a/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
@@ -49,6 +49,9 @@ spec:
               printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundWarning | grep -Fq 'cnpg_pg_database_mxid_age'
               printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundWarning | grep -Fq ') > 1500000000'
               printf '%s\n' "$rendered" | alert_rule CNPGClusterXIDWraparoundCritical | grep -Fq ') > 2000000000'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'kube_customresource_primary_failing_since_time'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'group_left(current_primary, target_primary)'
+              printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'for: 5m'
 
               one_instance="$(render 1)"
               if printf '%s\n' "$one_instance" | grep -Fq 'CNPGClusterHA'; then
@@ -66,12 +69,17 @@ spec:
                 --set 'cluster.monitoring.prometheusRule.excludeRules[0]=CNPGReplicationSlotInactive' \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention' \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[2]=CNPGClusterXIDWraparoundWarning' \
-                --set 'cluster.monitoring.prometheusRule.excludeRules[3]=CNPGClusterXIDWraparoundCritical')"
+                --set 'cluster.monitoring.prometheusRule.excludeRules[3]=CNPGClusterXIDWraparoundCritical' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[4]=CNPGClusterPrimaryFailing')"
               if printf '%s\n' "$excluded" | grep -Fq 'CNPGReplicationSlot'; then
                 echo "excluded replication slot alerts must not render"
                 exit 1
               fi
               if printf '%s\n' "$excluded" | grep -Fq 'CNPGClusterXIDWraparound'; then
                 echo "excluded transaction ID wraparound alerts must not render"
+                exit 1
+              fi
+              if printf '%s\n' "$excluded" | grep -Fq 'CNPGClusterPrimaryFailing'; then
+                echo "excluded primary failing alert must not render"
                 exit 1
               fi


### PR DESCRIPTION
## What

Adds the chart-native `CNPGClusterPrimaryFailing` critical alert and a concise runbook.

The rule fires only when CloudNativePG's primary-failing timestamp is already more than five minutes old and the expression remains true for another five minutes. `current_primary` and `target_primary` are joined as diagnostic labels; they do not trigger the alert.

## Why

The existing HA alerts measure streaming standby count, and the offline alert requires every instance to be unready. A cluster can therefore retain ready replicas while CNPG cannot establish a stable writable primary.

Successful promotions, planned switchovers, and brief automatic recovery remain silent.

## Validation

- shared Prometheus-rule rendering coverage
- primary-failing metric and diagnostic-label join assertions
- `excludeRules` coverage
- `helm lint charts/paradedb`
- codespell, Markdown lint, and repository hooks