### PR TITLE
feat(monitoring): alert on PgBouncer failures

### DIFF
--- a/charts/paradedb/docs/runbooks/CNPGPooler.md
+++ b/charts/paradedb/docs/runbooks/CNPGPooler.md
@@ -1,0 +1,53 @@
+# CNPGPooler
+
+## Description
+
+The `CNPGPoolerUnavailable` alert fires when a CloudNativePG-managed PgBouncer pooler has no available instances for five minutes. The `CNPGPoolerClientsWaiting` alert fires when clients remain queued for a server connection on a PgBouncer pod for five minutes.
+
+PgBouncer is the customer-facing connection endpoint. PostgreSQL can remain healthy while pooler failures or saturation prevent customers from connecting.
+
+## Impact
+
+- An unavailable read-write pooler prevents new customer database connections.
+- An unavailable read-only pooler prevents connections to the read endpoint.
+- Sustained waiting clients experience increased connection and query latency and may time out.
+
+## Diagnosis
+
+Inspect the Pooler resource, deployment, pods, and recent events:
+
+```bash
+kubectl get -n <namespace> pooler,deploy,pod
+kubectl describe -n <namespace> pooler/<pooler-name>
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+```
+
+Check PgBouncer logs and current pool state:
+
+```bash
+kubectl logs -n <namespace> deployment/<pooler-name> --since=30m
+kubectl exec -n <namespace> deployment/<pooler-name> -- psql pgbouncer -c "SHOW POOLS;"
+```
+
+If clients are waiting, determine whether PgBouncer has exhausted its server pool or PostgreSQL sessions are blocked. Check for database lock contention:
+
+```sql
+SELECT pid,
+       pg_blocking_pids(pid) AS blocked_by,
+       state,
+       wait_event_type,
+       wait_event,
+       now() - xact_start AS transaction_age,
+       query
+FROM pg_stat_activity
+WHERE cardinality(pg_blocking_pids(pid)) > 0
+ORDER BY xact_start;
+```
+
+## Mitigation
+
+For an unavailable pooler, correct scheduling, image, configuration, secret, or networking failures and allow CloudNativePG to restore the desired PgBouncer instances.
+
+For waiting clients, resolve the limiting server pool or database bottleneck. Increase pool sizes only after confirming PostgreSQL has enough connection capacity. If a database transaction is blocking other sessions, terminate it only after confirming that rolling it back is safe.
+
+Confirm afterward that the pooler has available replicas, `SHOW POOLS` reports no sustained client queue, customer connections succeed, and both alerts clear.

--- a/charts/paradedb/prometheus_rules/cluster-pooler_clients_waiting-warning.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-pooler_clients_waiting-warning.yaml
@@ -1,0 +1,24 @@
+{{- $alert := "CNPGPoolerClientsWaiting" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: Clients are waiting for PgBouncer server connections
+  description: |-
+    PgBouncer pod "{{ .labels.pod }}" for cluster "{{ .namespace }}/{{ .cluster }}" has
+    {{ .value }} clients waiting for a server connection. The queue has persisted for at
+    least five minutes and indicates customer-facing connection pressure.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGPooler.md
+expr: |
+  sum by (namespace, pod) (
+    cnpg_pgbouncer_pools_cl_waiting{
+      namespace="{{ .namespace }}",
+      pod=~"{{ .cluster }}-pooler-.+",
+      database!="pgbouncer"
+    }
+  ) > 0
+for: 5m
+labels:
+  severity: warning
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/prometheus_rules/cluster-pooler_unavailable-critical.yaml
+++ b/charts/paradedb/prometheus_rules/cluster-pooler_unavailable-critical.yaml
@@ -1,0 +1,20 @@
+{{- $alert := "CNPGPoolerUnavailable" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
+annotations:
+  summary: PgBouncer has no available instances
+  description: |-
+    Pooler "{{ .labels.deployment }}" for cluster "{{ .namespace }}/{{ .cluster }}" has no
+    available PgBouncer instances. Customer connections through this endpoint will fail.
+  runbook_url: https://github.com/paradedb/charts/blob/main/charts/paradedb/docs/runbooks/CNPGPooler.md
+expr: |
+  kube_deployment_status_replicas_available{
+    namespace="{{ .namespace }}",
+    deployment=~"{{ .cluster }}-pooler-.+"
+  } == 0
+for: 5m
+labels:
+  severity: critical
+  namespace: {{ .namespace }}
+  cnpg_cluster: {{ .cluster }}
+{{- end -}}

--- a/charts/paradedb/templates/prometheus-rule.yaml
+++ b/charts/paradedb/templates/prometheus-rule.yaml
@@ -19,7 +19,7 @@ spec:
         {{- $_ := set $dict "valuePercent" "{{ $value | humanizePercentage }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
-        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}" "datname" "{{ $labels.datname }}" "age_kind" "{{ $labels.age_kind }}" "current_primary" "{{ $labels.current_primary }}" "target_primary" "{{ $labels.target_primary }}") -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "deployment" "{{ $labels.deployment }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}" "slot_name" "{{ $labels.slot_name }}" "slot_type" "{{ $labels.slot_type }}" "persistentvolumeclaim" "{{ $labels.persistentvolumeclaim }}" "datname" "{{ $labels.datname }}" "age_kind" "{{ $labels.age_kind }}" "current_primary" "{{ $labels.current_primary }}" "target_primary" "{{ $labels.target_primary }}") -}}
         {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "pvcSelector" (printf "%s-([1-9][0-9]*)" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "Values"      .Values -}}

--- a/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
+++ b/charts/paradedb/test/prometheus-rule-rendering/chainsaw-test.yaml
@@ -52,6 +52,10 @@ spec:
               printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'kube_customresource_primary_failing_since_time'
               printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'group_left(current_primary, target_primary)'
               printf '%s\n' "$rendered" | alert_rule CNPGClusterPrimaryFailing | grep -Fq 'for: 5m'
+              printf '%s\n' "$rendered" | alert_rule CNPGPoolerUnavailable | grep -Fq 'kube_deployment_status_replicas_available'
+              printf '%s\n' "$rendered" | alert_rule CNPGPoolerUnavailable | grep -Fq 'deployment=~"alerts-3-paradedb-pooler-.+"'
+              printf '%s\n' "$rendered" | alert_rule CNPGPoolerClientsWaiting | grep -Fq 'cnpg_pgbouncer_pools_cl_waiting'
+              printf '%s\n' "$rendered" | alert_rule CNPGPoolerClientsWaiting | grep -Fq 'database!="pgbouncer"'
 
               one_instance="$(render 1)"
               if printf '%s\n' "$one_instance" | grep -Fq 'CNPGClusterHA'; then
@@ -70,7 +74,9 @@ spec:
                 --set 'cluster.monitoring.prometheusRule.excludeRules[1]=CNPGReplicationSlotHighRetention' \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[2]=CNPGClusterXIDWraparoundWarning' \
                 --set 'cluster.monitoring.prometheusRule.excludeRules[3]=CNPGClusterXIDWraparoundCritical' \
-                --set 'cluster.monitoring.prometheusRule.excludeRules[4]=CNPGClusterPrimaryFailing')"
+                --set 'cluster.monitoring.prometheusRule.excludeRules[4]=CNPGClusterPrimaryFailing' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[5]=CNPGPoolerUnavailable' \
+                --set 'cluster.monitoring.prometheusRule.excludeRules[6]=CNPGPoolerClientsWaiting')"
               if printf '%s\n' "$excluded" | grep -Fq 'CNPGReplicationSlot'; then
                 echo "excluded replication slot alerts must not render"
                 exit 1
@@ -81,5 +87,9 @@ spec:
               fi
               if printf '%s\n' "$excluded" | grep -Fq 'CNPGClusterPrimaryFailing'; then
                 echo "excluded primary failing alert must not render"
+                exit 1
+              fi
+              if printf '%s\n' "$excluded" | grep -Fq 'CNPGPooler'; then
+                echo "excluded PgBouncer alerts must not render"
                 exit 1
               fi

--- a/charts/paradedb/test/replica/06-replica_object_store_cluster.yaml
+++ b/charts/paradedb/test/replica/06-replica_object_store_cluster.yaml
@@ -1,5 +1,8 @@
 type: paradedb-enterprise
 mode: replica
+version:
+  major: "18"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/replica/08-replica_hybrid_cluster.yaml
+++ b/charts/paradedb/test/replica/08-replica_hybrid_cluster.yaml
@@ -1,5 +1,8 @@
 type: paradedb-enterprise
 mode: replica
+version:
+  major: "18"
+  paradedb: "0.25.0"
 cluster:
   instances: 1
   storage:


### PR DESCRIPTION
## What

- alert when a CloudNativePG PgBouncer pooler has no available replicas for five minutes
- alert when clients remain queued for server connections for five minutes
- add a concise shared runbook for diagnosing pooler availability, pool exhaustion, and PostgreSQL blocking
- cover rendering and rule exclusion in the shared monitoring Chainsaw test

## Why

PgBouncer can fail or become a customer-facing bottleneck while PostgreSQL itself remains healthy. These alerts focus on actionable failures rather than normal pooler activity. A five-minute hold avoids alerting on brief queue spikes; production history showed short waits of up to four clients but no continuously non-empty queue over five minutes.

A percentage-based client saturation alert is intentionally omitted because the exported metrics do not provide a reliable max_client_conn denominator.

Implements the chart-side rules for paradedb/mcc#187.

## Validation

- helm lint charts/paradedb
- monitoring rule render and exclusion assertions
- repository pre-commit hooks