### PR TITLE
chore: upgrade ParadeDB to 0.25.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 
 cluster:
   instances: 1

--- a/charts/paradedb/Chart.yaml
+++ b/charts/paradedb/Chart.yaml
@@ -27,8 +27,8 @@ type: application
 version: 0.0.0-generated-in-ci
 
 # The ParadeDB version, set in the publish CI workflow from the latest paradedb/paradedb GitHub tag
-# We default to v0.25.0 for testing and local development
-appVersion: 0.25.0
+# We default to v0.25.6 for testing and local development
+appVersion: 0.25.6
 
 sources:
   - https://github.com/paradedb/charts

--- a/charts/paradedb/README.md
+++ b/charts/paradedb/README.md
@@ -46,7 +46,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 
 cluster:
   instances: 1
@@ -465,7 +465,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | replica.self | string | `""` | Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default. |
 | subscriptions | list | `[]` | Declarative logical replication subscriptions (CNPG `Subscription` resources) |
 | type | string | `"paradedb"` | Type of the CNPG database. Available types: * `paradedb` * `paradedb-enterprise` |
-| version.paradedb | string | `"0.25.0"` | ParadeDB version to use |
+| version.paradedb | string | `"0.25.6"` | ParadeDB version to use |
 | version.postgresql | string | `"18"` | PostgreSQL major version to use |
 | poolers[].name | string | `` | Name of the pooler resource |
 | poolers[].instances | number | `1` | The number of replicas we want |

--- a/charts/paradedb/README.md.gotmpl
+++ b/charts/paradedb/README.md.gotmpl
@@ -46,7 +46,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 
 cluster:
   instances: 1

--- a/charts/paradedb/examples/image-catalog-ref.yaml
+++ b/charts/paradedb/examples/image-catalog-ref.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   imageCatalogRef:

--- a/charts/paradedb/examples/image-catalog.yaml
+++ b/charts/paradedb/examples/image-catalog.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
 backups:

--- a/charts/paradedb/examples/paradedb.yaml
+++ b/charts/paradedb/examples/paradedb.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   postgresql: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
 backups:

--- a/charts/paradedb/test/console-statefulset/01-console_test_cluster.yaml
+++ b/charts/paradedb/test/console-statefulset/01-console_test_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   postgresql: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   console:

--- a/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
+++ b/charts/paradedb/test/paradedb-enterprise/01-paradedb-NCC-1701-D_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 2
   storage:

--- a/charts/paradedb/test/paradedb-minio-backup-restore/01-paradedb_cluster.yaml
+++ b/charts/paradedb/test/paradedb-minio-backup-restore/01-paradedb_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 2
   storage:

--- a/charts/paradedb/test/replica/01-source_cluster_enterprise.yaml
+++ b/charts/paradedb/test/replica/01-source_cluster_enterprise.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/replica/04-replica_cluster_enterprise.yaml
+++ b/charts/paradedb/test/replica/04-replica_cluster_enterprise.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: replica
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/replica/06-replica_object_store_cluster.yaml
+++ b/charts/paradedb/test/replica/06-replica_object_store_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: replica
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/replica/08-replica_hybrid_cluster.yaml
+++ b/charts/paradedb/test/replica/08-replica_hybrid_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb-enterprise
 mode: replica
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/test/scheduledbackups/01-scheduledbackups_cluster.yaml
+++ b/charts/paradedb/test/scheduledbackups/01-scheduledbackups_cluster.yaml
@@ -2,7 +2,7 @@ type: paradedb
 mode: standalone
 version:
   major: "18"
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 cluster:
   instances: 1
   storage:

--- a/charts/paradedb/values.schema.json
+++ b/charts/paradedb/values.schema.json
@@ -1542,7 +1542,7 @@
     "version": {
       "properties": {
         "paradedb": {
-          "default": "0.25.0",
+          "default": "0.25.6",
           "description": "ParadeDB version to use",
           "type": "string"
         },

--- a/charts/paradedb/values.yaml
+++ b/charts/paradedb/values.yaml
@@ -14,7 +14,7 @@ version:
   # -- PostgreSQL major version to use
   postgresql: "18"
   # -- ParadeDB version to use
-  paradedb: "0.25.0"
+  paradedb: "0.25.6"
 
 # -- Cluster mode of operation. Available modes:
 # * `standalone` - default mode. Creates new or updates an existing CNPG cluster.
@@ -689,7 +689,7 @@ databases: []
  #   extensions: []                 # -- List of extensions to be created in the database.
  #    # - name: pg_search
  #    #   ensure: present           # -- Ensure the PostgreSQL extension is present or absent - defaults to "present".
- #    #   version: "0.25.0"         # -- Version of the extension to be installed, if not specified the latest version will be used.
+ #    #   version: "0.25.6"         # -- Version of the extension to be installed, if not specified the latest version will be used.
  #    #   schema: ""                # -- Schema where the extension will be installed, if not specified the extensions or current default object creation schema will be used.
  #   isTemplate: false              # -- Maps to the IS_TEMPLATE parameter. If true, the database is considered a template for new databases.
  #   locale: ""                     # -- Maps to the LC_COLLATE and LC_CTYPE parameters


### PR DESCRIPTION
## Summary

- update the default ParadeDB application and image version from 0.25.0 to 0.25.6
- update examples and test fixtures to exercise 0.25.6
- regenerate the chart README and values schema

## Validation

- `make docs schema`
- `helm lint charts/paradedb`
- rendered the default chart and every example values file
- `jq empty charts/paradedb/values.schema.json`
- `markdownlint README.md charts/paradedb/README.md.gotmpl`
- `git diff --check`